### PR TITLE
Remove duplicate line

### DIFF
--- a/libraries/provider_mysql_service_sysvinit.rb
+++ b/libraries/provider_mysql_service_sysvinit.rb
@@ -16,7 +16,6 @@ class Chef
               mysql_name: mysql_name,
               mysqladmin_bin: mysqladmin_bin,
               mysqld_safe_bin: mysqld_safe_bin,
-              mysqld_safe_bin: mysqld_safe_bin,
               pid_file: pid_file,
               scl_name: scl_name
               )


### PR DESCRIPTION
To silence warning

```
.../cookbooks/mysql/libraries/provider_mysql_service_sysvinit.rb:18: warning: duplicated key at line 19 ignored: :mysqld_safe_bin
```