### PR TITLE
Moved --defaults-file as first option in mysql_install_db_script

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -97,10 +97,10 @@ module MysqlCookbook
       if scl_package?
         <<-EOF
           scl enable #{scl_name} \
-          "#{mysql_install_db_bin} --datadir=#{parsed_data_dir} --defaults-file=#{etc_dir}/my.cnf"
+          "#{mysql_install_db_bin} --defaults-file=#{etc_dir}/my.cnf --datadir=#{parsed_data_dir}"
           EOF
       else
-        "#{mysql_install_db_bin} --datadir=#{parsed_data_dir} --defaults-file=#{etc_dir}/my.cnf"
+        "#{mysql_install_db_bin} --defaults-file=#{etc_dir}/my.cnf --datadir=#{parsed_data_dir}"
       end
     end
 


### PR DESCRIPTION
According to the MySQL manual the --defaults-file option must be given before other options, see:
http://dev.mysql.com/doc/refman/5.7/en/option-file-options.html

Not doing this might cause an error like:
mysql_install_db: [ERROR] unknown variable 'defaults-file=/etc/mysql-default/my.cnf'