### PR TITLE
Explain socket based workaround for broken local MySQL access.

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,24 +428,21 @@ like this one:
 
 `Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock'`
 
-This is because the server LWRP deletes the hardcoded /etc/my.cnf to
-avoid multiple MySQL instances sharing that config file. The socket
-for the instance is set in /etc/mysql-[instance]/my.cnf.
+This is because MySQL is hardcoded to read the defined default my.cnf
+file, typically at /etc/my.cnf, and this LWRP deletes it to prevent
+overlap among multiple MySQL configurations. 
 
-To connect to the socket, use something like this based on the correct
-my.cnf file settings.
+To connect to the socket from the command line, check the socket in the relevant my.cnf file and use something like this:
 
 `mysql -S /var/run/mysql-default/mysqld.sock -Pwhatever`
 
-Or add something like this to your $HOME/.my.cnf:
-
-`[client]
-socket = /var/run/mysql-default/mysqld.sock'
-
-Or to connect to a database via the local network from the command line,
-you'll need to specify additional flags and connect over the network..
+Or to connect over the network, use something like this:
+connect over the network..
 
 `mysql -h 127.0.0.1 -Pwhatever`
+
+These network or socket ssettings can also be put in you
+$HOME/.my.cnf, if preferred.
 
 ### What about MariaDB, Percona, Drizzle, WebScaleSQL, etc.
 

--- a/README.md
+++ b/README.md
@@ -428,8 +428,22 @@ like this one:
 
 `Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock'`
 
-To connect to a database from the command line, you'll need to specify
-additional flags and connect over the network..
+This is because the server LWRP deletes the hardcoded /etc/my.cnf to
+avoid multiple MySQL instances sharing that config file. The socket
+for the instance is set in /etc/mysql-[instance]/my.cnf.
+
+To connect to the socket, use something like this based on the correct
+my.cnf file settings.
+
+`mysql -S /var/run/mysql-default/mysqld.sock -Pwhatever`
+
+Or add something like this to your $HOME/.my.cnf:
+
+`[client]
+socket = /var/run/mysql-default/mysqld.sock'
+
+Or to connect to a database via the local network from the command line,
+you'll need to specify additional flags and connect over the network..
 
 `mysql -h 127.0.0.1 -Pwhatever`
 
@@ -444,6 +458,9 @@ Package repository locations, package version names, software major
 version numbers, supported platform matrices, and the availability of
 software such as XtraDB and Galera are the main reasons that creating
 multiple cookbooks to make sense.
+
+Warnings
+--------
 
 Hacking / Testing / TODO
 -------------------------


### PR DESCRIPTION
The local MySQL access breadks because the new instances have a different default 'mysql.sock' location, and the LWRP deletes the default /etc/my.cnf. So the binaries look in the wrong place for the socket.

This provides a better explanation of the problem, and more detailed workarounds. This is especially useful for MySQL where network access is blocked and only socket access works.