### PR TITLE
Added support for amazon linux 2015.03

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -282,6 +282,14 @@ EOSQL
         @pkginfo.set['rhel']['2014.09']['5.6']['server_package'] = 'mysql-community-server'
         @pkginfo.set['rhel']['2014.09']['5.7']['client_package'] = %w(mysql-community-client mysql-community-devel)
         @pkginfo.set['rhel']['2014.09']['5.7']['server_package'] = 'mysql-community-server'
+        @pkginfo.set['rhel']['2015.03']['5.1']['server_package'] = %w(mysql51 mysql51-devel)
+        @pkginfo.set['rhel']['2015.03']['5.1']['server_package'] = 'mysql51-server'
+        @pkginfo.set['rhel']['2015.03']['5.5']['client_package'] = %w(mysql-community-client mysql-community-devel)
+        @pkginfo.set['rhel']['2015.03']['5.5']['server_package'] = 'mysql-community-server'
+        @pkginfo.set['rhel']['2015.03']['5.6']['client_package'] = %w(mysql-community-client mysql-community-devel)
+        @pkginfo.set['rhel']['2015.03']['5.6']['server_package'] = 'mysql-community-server'
+        @pkginfo.set['rhel']['2015.03']['5.7']['client_package'] = %w(mysql-community-client mysql-community-devel)
+        @pkginfo.set['rhel']['2015.03']['5.7']['server_package'] = 'mysql-community-server'
         @pkginfo.set['rhel']['5']['5.0']['client_package'] = %w(mysql mysql-devel)
         @pkginfo.set['rhel']['5']['5.0']['server_package'] = 'mysql-server'
         @pkginfo.set['rhel']['5']['5.1']['client_package'] = %w(mysql51-mysql)
@@ -393,6 +401,7 @@ EOSQL
       return '5.5' if node['platform_family'] == 'freebsd'
       return '5.5' if node['platform_family'] == 'omnios'
       return '5.5' if node['platform_family'] == 'rhel' && node['platform_version'].to_i == 2014
+      return '5.5' if node['platform_family'] == 'rhel' && node['platform_version'].to_i == 2015
       return '5.5' if node['platform_family'] == 'rhel' && node['platform_version'].to_i == 7
       return '5.5' if node['platform_family'] == 'smartos'
       return '5.5' if node['platform_family'] == 'suse'


### PR DESCRIPTION
A new amazon linux version is out which breaks the support with this cookbook. 
Support is added for the amazon linux version 2015.03