### PR TITLE
add mysqld_options resource attribute

### DIFF
--- a/libraries/resource_mysql_service.rb
+++ b/libraries/resource_mysql_service.rb
@@ -19,6 +19,7 @@ class Chef
       attribute :run_group, kind_of: String, default: 'mysql'
       attribute :run_user, kind_of: String, default: 'mysql'
       attribute :socket, kind_of: String, default: nil
+      attribute :mysqld_options, kind_of: Hash, default: {}
       attribute :version, kind_of: String, default: nil
     end
   end

--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -38,6 +38,9 @@ datadir                        = <%= @data_dir %>
 <% if @tmp_dir %>
 tmpdir                         = <%= @tmp_dir %>
 <% end %>
+<% @config.mysqld_options.each do |option,value| %>
+<%= option %>                  = <%= value %>
+<% end %>
 <% if @lc_messages_dir %>
 lc-messages-dir                = <%= @lc_messages_dir %>
 <% end %>


### PR DESCRIPTION
I've added the attribute to close the issue https://github.com/chef-cookbooks/mysql/issues/233 I've faced with too.
`mysqld_options` will allow to setup mysqld server options upon a service installation. 