### PR TITLE
Pre-start script for Upstart does not properly create custom socket directory.

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -221,6 +221,11 @@ EOSQL
       "#{run_dir}/mysqld.sock"
     end
 
+    def socket_dir
+      return File.dirname(new_resource.socket) if new_resource.socket
+      run_dir
+    end
+
     def tmp_dir
       '/tmp'
     end

--- a/libraries/provider_mysql_service_upstart.rb
+++ b/libraries/provider_mysql_service_upstart.rb
@@ -25,7 +25,7 @@ class Chef
               mysql_name: mysql_name,
               run_group: new_resource.run_group,
               run_user: new_resource.run_user,
-              socket_file: socket_file
+              socket_dir: socket_dir
               )
             cookbook 'mysql'
             action :create

--- a/templates/default/upstart/mysqld.erb
+++ b/templates/default/upstart/mysqld.erb
@@ -15,7 +15,7 @@ umask 007
 kill timeout 300
 
 pre-start script
-[ -d /run/<%= @mysql_name %> ] || install -m 755 -o <%= @run_user %> -g <%= @run_group %> -d /run/<%= @mysql_name %>
+[ -d <%= @socket_dir %> ] || install -m 755 -o <%= @run_user %> -g <%= @run_group %> -d <%= @socket_dir %>
 end script
 
 exec /usr/sbin/mysqld --defaults-file=<%= @defaults_file %>


### PR DESCRIPTION
When using a custom socket directory (e.g. `/var/run/mysqld/mysqld.sock`), the template for the Upstart script does not work properly. It attempts to create the necessary parent directory based on instance name. This does not work unless the default socket is used.