### PR TITLE
changed the way to test if a file exists

### DIFF
--- a/libraries/provider_mysql_service.rb
+++ b/libraries/provider_mysql_service.rb
@@ -146,7 +146,7 @@ class Chef
         bash "#{new_resource.name} :create initial records" do
           code init_records_script
           returns [0, 1, 2] # facepalm
-          not_if "/usr/bin/test -f #{parsed_data_dir}/mysql/user.frm"
+          not_if { ::File.exists?("#{parsed_data_dir}/mysql/user.frm") }
           action :run
         end
       end


### PR DESCRIPTION
changed the way to test if a file exists, using a Chef's function for
this instead of an OS function

With Ubuntu 12.04.5 does not work "test -f [file]"