### PR TITLE
Mysql with data dir isn't installing

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -121,6 +121,7 @@ module MysqlCookbook
       cmd = mysql_install_db_bin
       cmd << " --defaults-file=#{etc_dir}/my.cnf"
       cmd << " --datadir=#{parsed_data_dir}"
+      cmd << ' --explicit_defaults_for_timestamp' if v56plus
       return "scl enable #{scl_name} \"#{cmd}\"" if scl_package?
       cmd
     end


### PR DESCRIPTION
The following isn't working on ubuntu 14.04.

mysql_service 'default' do
  port '3306'
  version '5.6'
  bind_address '127.0.0.1'
  initial_root_password "#{pwd}"
  data_dir '/data/mysql'
  action [:create, :start]
end

It is failing with following error:
==> default: Mixlib::ShellOut::ShellCommandFailed
==> default: ------------------------------------
==> default: bash[default :create initial records] (/tmp/vagrant-chef/bc96c019bc331514b85df82e02830025/cookbooks/mysql/libraries/provider_mysql_service.rb line 146) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0, 1, 2], but received '141'
==> default: ---- Begin output of "bash"  "/tmp/chef-script20150401-11145-1act0l9" ----
==> default: STDOUT: Installing MySQL system tables...
==> default: STDERR: 2015-04-01 20:04:25 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
==> default: ---- End output of "bash"  "/tmp/chef-script20150401-11145-1act0l9" ----
==> default: Ran "bash"  "/tmp/chef-script20150401-11145-1act0l9" returned 141
==> default: 
==> default: Resource Declaration:
==> default: ---------------------
==> default: # In /tmp/vagrant-chef/bc96c019bc331514b85df82e02830025/cookbooks/patrolserver-backend/recipes/default.rb
==> default: 
==> default:  45: mysql_service 'default' do
==> default:  46:   port '3306'
==> default:  47:   version '5.6'
==> default:  48:   bind_address '127.0.0.1'
==> default:  49:   initial_root_password "#{pwd}"
==> default:  50:   data_dir '/data/mysql'
==> default:  51:   action [:create, :start]
==> default:  52: end
==> default:  53: 
==> default: 
==> default: Compiled Resource:
==> default: ------------------
==> default: # Declared in /tmp/vagrant-chef/bc96c019bc331514b85df82e02830025/cookbooks/patrolserver-backend/recipes/default.rb:45:in `from_file'
==> default: 
==> default: mysql_service("default") do
==> default:   action [:create, :start]
==> default:   updated true
==> default:   updated_by_last_action true
==> default:   retries 0
==> default:   retry_delay 2
==> default:   default_guard_interpreter :default
==> default:   declared_type :mysql_service
==> default:   cookbook_name :"patrolserver-backend"
==> default:   recipe_name "default"
==> default:   port "3306"
==> default:   version "5.6"
==> default:   bind_address "127.0.0.1"
==> default:   initial_root_password "DO1VG2cYYaHJK@aTitT4"
==> default:   data_dir "/data/mysql"
==> default:   package_action :install
==> default:   instance "default"
==> default:   run_user "mysql"
==> default:   run_group "mysql"
==> default:   charset "utf8"
==> default: end
==> default: 
==> default: [2015-04-01T20:04:31+00:00] INFO: Running queued delayed notifications before re-raising exception
==> default: [2015-04-01T20:04:31+00:00] ERROR: Running exception handlers
==> default: [2015-04-01T20:04:31+00:00] ERROR: Exception handlers complete
==> default: [2015-04-01T20:04:31+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
==> default: [2015-04-01T20:04:31+00:00] ERROR: mysql_service[default] (patrolserver-backend::default line 45) had an error: Mixlib::ShellOut::ShellCommandFailed: bash[default :create initial records] (/tmp/vagrant-chef/bc96c019bc331514b85df82e02830025/cookbooks/mysql/libraries/provider_mysql_service.rb line 146) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0, 1, 2], but received '141'
==> default: ---- Begin output of "bash"  "/tmp/chef-script20150401-11145-1act0l9" ----
==> default: STDOUT: Installing MySQL system tables...
==> default: STDERR: 2015-04-01 20:04:25 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
==> default: ---- End output of "bash"  "/tmp/chef-script20150401-11145-1act0l9" ----
==> default: Ran "bash"  "/tmp/chef-script20150401-11145-1act0l9" returned 141
==> default: [2015-04-01T20:04:31+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)