### PR TITLE
Pre-start script for Upstart does not properly create run directory (for pid) when using custom socket.

### DIFF
--- a/templates/default/upstart/mysqld.erb
+++ b/templates/default/upstart/mysqld.erb
@@ -15,6 +15,7 @@ umask 007
 kill timeout 300
 
 pre-start script
+[ -d /run/<%= @mysql_name %> ] || install -m 755 -o <%= @run_user %> -g <%= @run_group %> -d /run/<%= @mysql_name %>
 [ -d <%= @socket_dir %> ] || install -m 755 -o <%= @run_user %> -g <%= @run_group %> -d <%= @socket_dir %>
 end script
 


### PR DESCRIPTION
When using a custom socket directory (e.g. `/var/run/mysqld/mysqld.sock`), the template for the Upstart script not longer creates the run directory at `/var/run/mysql-instancename` which, by default, is where the pidfile is placed. If the directory does not exist, MySQL will fail to start. I introduced this myself in #318. :( Adding back in the original run directory, and continue to ensure that the socket directory also exists.