### PR TITLE
Stop polluting Chef::Resource with methods

### DIFF
--- a/libraries/resource_mysql_service.rb
+++ b/libraries/resource_mysql_service.rb
@@ -26,118 +26,118 @@ class Chef
       attribute :enable_utf8, :kind_of => String, :default => false
 
       include Opscode::Mysql::Helpers
-    end
 
-    def parsed_allow_remote_root
-      return allow_remote_root unless allow_remote_root.nil?
-    end
-
-    def parsed_data_dir
-      return data_dir if data_dir
-      case node['platform_family']
-      when 'rhel', 'fedora', 'suse', 'debian', 'omnios'
-        data_dir = '/var/lib/mysql'
-      when 'smartos'
-        data_dir = '/opt/local/lib/mysql'
-      when 'freebsd'
-        data_dir = '/var/db/mysql'
+      def parsed_allow_remote_root
+        return allow_remote_root unless allow_remote_root.nil?
       end
-      data_dir
-    end
 
-    def parsed_package_name
-      return package_name if package_name
-      package_name_for(
-        node['platform'],
-        node['platform_family'],
-        node['platform_version'],
-        parsed_version
-        )
-    end
+      def parsed_data_dir
+        return data_dir if data_dir
+        case node['platform_family']
+        when 'rhel', 'fedora', 'suse', 'debian', 'omnios'
+          data_dir = '/var/lib/mysql'
+        when 'smartos'
+          data_dir = '/opt/local/lib/mysql'
+        when 'freebsd'
+          data_dir = '/var/db/mysql'
+        end
+        data_dir
+      end
 
-    def parsed_package_version
-      return package_version if package_version
-    end
+      def parsed_package_name
+        return package_name if package_name
+        package_name_for(
+          node['platform'],
+          node['platform_family'],
+          node['platform_version'],
+          parsed_version
+          )
+      end
 
-    def parsed_package_action
-      return package_action if package_action
-    end
+      def parsed_package_version
+        return package_version if package_version
+      end
 
-    def parsed_port
-      return port if port
-    end
+      def parsed_package_action
+        return package_action if package_action
+      end
 
-    def parsed_remove_anonymous_users
-      return remove_anonymous_users unless remove_anonymous_users.nil?
-    end
+      def parsed_port
+        return port if port
+      end
 
-    def parsed_remove_test_database
-      return remove_test_database unless remove_test_database.nil?
-    end
+      def parsed_remove_anonymous_users
+        return remove_anonymous_users unless remove_anonymous_users.nil?
+      end
 
-    def parsed_root_network_acl
-      return root_network_acl if root_network_acl
-    end
+      def parsed_remove_test_database
+        return remove_test_database unless remove_test_database.nil?
+      end
 
-    def parsed_server_debian_password
-      return server_debian_password if server_debian_password
-    end
+      def parsed_root_network_acl
+        return root_network_acl if root_network_acl
+      end
 
-    def parsed_server_repl_password
-      return server_repl_password if server_repl_password
-    end
+      def parsed_server_debian_password
+        return server_debian_password if server_debian_password
+      end
 
-    def parsed_server_root_password
-      return server_root_password if server_root_password
-    end
+      def parsed_server_repl_password
+        return server_repl_password if server_repl_password
+      end
 
-    def parsed_service_name
-      return service_name if service_name
-    end
+      def parsed_server_root_password
+        return server_root_password if server_root_password
+      end
 
-    def parsed_template_source
-      return template_source if template_source
-    end
+      def parsed_service_name
+        return service_name if service_name
+      end
 
-    def parsed_version
-      return version if version
-      case node['platform_family']
-      when 'rhel'
-        case node['platform_version'].to_i
-        when 5
-          default_version = '5.0'
-        when 2013, 6
-          default_version = '5.1'
-        when 2014, 7
+      def parsed_template_source
+        return template_source if template_source
+      end
+
+      def parsed_version
+        return version if version
+        case node['platform_family']
+        when 'rhel'
+          case node['platform_version'].to_i
+          when 5
+            default_version = '5.0'
+          when 2013, 6
+            default_version = '5.1'
+          when 2014, 7
+            default_version = '5.5'
+          end
+        when 'fedora'
+          default_version = '5.5'
+        when 'suse'
+          default_version = '5.5'
+        when 'debian'
+          return '5.1' if node['platform_version'].to_i == 6
+          return '5.5' if node['platform_version'].to_i == 7
+          case node['platform_version']
+          when '14.10'
+            default_version = '5.6'
+          when 'jessie/sid', '12.04', '13.04', '13.10', '14.04'
+            default_version = '5.5'
+          when '10.04'
+            default_version = '5.1'
+          end
+        when 'smartos'
+          default_version = '5.5'
+        when 'omnios'
+          default_version = '5.5'
+        when 'freebsd'
           default_version = '5.5'
         end
-      when 'fedora'
-        default_version = '5.5'
-      when 'suse'
-        default_version = '5.5'
-      when 'debian'
-        return '5.1' if node['platform_version'].to_i == 6
-        return '5.5' if node['platform_version'].to_i == 7
-        case node['platform_version']
-        when '14.10'
-          default_version = '5.6'
-        when 'jessie/sid', '12.04', '13.04', '13.10', '14.04'
-          default_version = '5.5'
-        when '10.04'
-          default_version = '5.1'
-        end
-      when 'smartos'
-        default_version = '5.5'
-      when 'omnios'
-        default_version = '5.5'
-      when 'freebsd'
-        default_version = '5.5'
+        default_version
       end
-      default_version
-    end
 
-    def parsed_enable_utf8
-      return enable_utf8 if enable_utf8
+      def parsed_enable_utf8
+        return enable_utf8 if enable_utf8
+      end
     end
   end
 end


### PR DESCRIPTION
- RE: https://github.com/chef-cookbooks/mysql/issues/328, those on 5.x series are still seeing methods on Chef::Resource that are breaking other cookbooks like git.

- This moves _all_ methods from Chef::Resource to Chef::Resource::MysqlService