### PR TITLE
Change GRANT for root to localhost

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,5 +1,6 @@
 driver:
   name: vagrant
+  require_chef_omnibus: 12.3.0
   customize:
     memory: 1024
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -110,6 +110,11 @@ module MysqlCookbook
       'password'
     end
 
+    def password_column_name
+      return ", password_expired='N'" if v57plus
+      ''
+    end
+
     # database and initial records
     # initialization commands
 
@@ -153,7 +158,7 @@ module MysqlCookbook
         mkdir /tmp/#{mysql_name}
 
         cat > /tmp/#{mysql_name}/my.sql <<-EOSQL
-UPDATE mysql.user SET #{password_column_name}=PASSWORD('#{Shellwords.escape(new_resource.initial_root_password)}'), password_expired='N' WHERE user = 'root';
+UPDATE mysql.user SET #{password_column_name}=PASSWORD('#{Shellwords.escape(new_resource.initial_root_password)}')#{password_column_name} WHERE user = 'root';
 DELETE FROM mysql.user WHERE USER LIKE '';
 DELETE FROM mysql.user WHERE user = 'root' and host NOT IN ('127.0.0.1', 'localhost');
 FLUSH PRIVILEGES;

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -148,12 +148,11 @@ module MysqlCookbook
         mkdir /tmp/#{mysql_name}
 
         cat > /tmp/#{mysql_name}/my.sql <<-EOSQL
-DELETE FROM mysql.user ;
-CREATE USER 'root'@'127.0.0.1' IDENTIFIED BY '#{Shellwords.escape(new_resource.initial_root_password)}' ;
-GRANT ALL ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION ;
-CREATE USER 'root'@'localhost' IDENTIFIED BY '#{Shellwords.escape(new_resource.initial_root_password)}' ;
-GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION ;
+UPDATE mysql.user SET Password=PASSWORD('#{Shellwords.escape(new_resource.initial_root_password)}') WHERE user = 'root';
+DELETE FROM mysql.user WHERE USER LIKE '';
+DELETE FROM mysql.user WHERE user = 'root' and host NOT IN ('127.0.0.1', 'localhost');
 FLUSH PRIVILEGES;
+DELETE FROM MYSQL.DB WHERE DB LIKE 'test%'
 DROP DATABASE IF EXISTS test ;
 EOSQL
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -105,6 +105,11 @@ module MysqlCookbook
       true
     end
 
+    def password_column_name
+      return 'authentication_string' if v57plus
+      'password'
+    end
+
     # database and initial records
     # initialization commands
 
@@ -148,7 +153,7 @@ module MysqlCookbook
         mkdir /tmp/#{mysql_name}
 
         cat > /tmp/#{mysql_name}/my.sql <<-EOSQL
-UPDATE mysql.user SET password=PASSWORD('#{Shellwords.escape(new_resource.initial_root_password)}') WHERE user = 'root';
+UPDATE mysql.user SET #{password_column_name}=PASSWORD('#{Shellwords.escape(new_resource.initial_root_password)}'), password_expired='N' WHERE user = 'root';
 DELETE FROM mysql.user WHERE USER LIKE '';
 DELETE FROM mysql.user WHERE user = 'root' and host NOT IN ('127.0.0.1', 'localhost');
 FLUSH PRIVILEGES;

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -148,11 +148,11 @@ module MysqlCookbook
         mkdir /tmp/#{mysql_name}
 
         cat > /tmp/#{mysql_name}/my.sql <<-EOSQL
-UPDATE mysql.user SET Password=PASSWORD('#{Shellwords.escape(new_resource.initial_root_password)}') WHERE user = 'root';
+UPDATE mysql.user SET password=PASSWORD('#{Shellwords.escape(new_resource.initial_root_password)}') WHERE user = 'root';
 DELETE FROM mysql.user WHERE USER LIKE '';
 DELETE FROM mysql.user WHERE user = 'root' and host NOT IN ('127.0.0.1', 'localhost');
 FLUSH PRIVILEGES;
-DELETE FROM MYSQL.DB WHERE DB LIKE 'test%'
+DELETE FROM mysql.db WHERE db LIKE 'test%'
 DROP DATABASE IF EXISTS test ;
 EOSQL
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -150,7 +150,7 @@ module MysqlCookbook
         cat > /tmp/#{mysql_name}/my.sql <<-EOSQL
 DELETE FROM mysql.user ;
 CREATE USER 'root'@'%' IDENTIFIED BY '#{Shellwords.escape(new_resource.initial_root_password)}' ;
-GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
+GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION ;
 FLUSH PRIVILEGES;
 DROP DATABASE IF EXISTS test ;
 EOSQL

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -149,6 +149,8 @@ module MysqlCookbook
 
         cat > /tmp/#{mysql_name}/my.sql <<-EOSQL
 DELETE FROM mysql.user ;
+CREATE USER 'root'@'127.0.0.1' IDENTIFIED BY '#{Shellwords.escape(new_resource.initial_root_password)}' ;
+GRANT ALL ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION ;
 CREATE USER 'root'@'localhost' IDENTIFIED BY '#{Shellwords.escape(new_resource.initial_root_password)}' ;
 GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION ;
 FLUSH PRIVILEGES;

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -110,7 +110,7 @@ module MysqlCookbook
       'password'
     end
 
-    def password_column_name
+    def password_expired
       return ", password_expired='N'" if v57plus
       ''
     end
@@ -158,7 +158,7 @@ module MysqlCookbook
         mkdir /tmp/#{mysql_name}
 
         cat > /tmp/#{mysql_name}/my.sql <<-EOSQL
-UPDATE mysql.user SET #{password_column_name}=PASSWORD('#{Shellwords.escape(new_resource.initial_root_password)}')#{password_column_name} WHERE user = 'root';
+UPDATE mysql.user SET #{password_column_name}=PASSWORD('#{Shellwords.escape(new_resource.initial_root_password)}')#{password_expired} WHERE user = 'root';
 DELETE FROM mysql.user WHERE USER LIKE '';
 DELETE FROM mysql.user WHERE user = 'root' and host NOT IN ('127.0.0.1', 'localhost');
 FLUSH PRIVILEGES;

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -149,7 +149,7 @@ module MysqlCookbook
 
         cat > /tmp/#{mysql_name}/my.sql <<-EOSQL
 DELETE FROM mysql.user ;
-CREATE USER 'root'@'%' IDENTIFIED BY '#{Shellwords.escape(new_resource.initial_root_password)}' ;
+CREATE USER 'root'@'localhost' IDENTIFIED BY '#{Shellwords.escape(new_resource.initial_root_password)}' ;
 GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION ;
 FLUSH PRIVILEGES;
 DROP DATABASE IF EXISTS test ;

--- a/test/integration/service50-multi/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service50-multi/serverspec/assert_functioning_spec.rb
@@ -17,7 +17,7 @@ def mysqld_bin
   '/usr/sbin/mysqld'
 end
 
-def instance_1_cmd
+def instance_1_cmd_1
   <<-EOF
   #{mysql_bin} \
   -h 127.0.0.1 \
@@ -29,7 +29,19 @@ def instance_1_cmd
   EOF
 end
 
-def instance_2_cmd
+def instance_1_cmd_2
+  <<-EOF
+  #{mysql_bin} \
+  -h 127.0.0.1 \
+  -P 3307 \
+  -u root \
+  -pilikerandompasswords \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
+  --skip-column-names
+  EOF
+end
+
+def instance_2_cmd_1
   <<-EOF
   #{mysql_bin} \
   -h 127.0.0.1 \
@@ -41,18 +53,40 @@ def instance_2_cmd
   EOF
 end
 
+def instance_2_cmd_2
+  <<-EOF
+  #{mysql_bin} \
+  -h 127.0.0.1 \
+  -P 3308 \
+  -u root \
+  -pstring\\ with\\ spaces \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
+  --skip-column-names
+  EOF
+end
+
 def mysqld_cmd
   "#{mysqld_bin} --version"
 end
 
-describe command(instance_1_cmd) do
+describe command(instance_1_cmd_1) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
-describe command(instance_2_cmd) do
+describe command(instance_1_cmd_2) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/| localhost | root |/) }
+end
+
+describe command(instance_2_cmd_1) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| 127.0.0.1 | root |/) }
+end
+
+describe command(instance_2_cmd_1) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/| localhost | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service50-multi/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service50-multi/serverspec/assert_functioning_spec.rb
@@ -24,7 +24,7 @@ def instance_1_cmd
   -P 3307 \
   -u root \
   -pilikerandompasswords \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='%';" \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
   --skip-column-names
   EOF
 end
@@ -36,7 +36,7 @@ def instance_2_cmd
   -P 3308 \
   -u root \
   -pstring\\ with\\ spaces \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='%';" \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
   --skip-column-names
   EOF
 end
@@ -47,12 +47,12 @@ end
 
 describe command(instance_1_cmd) do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| % | root |/) }
+  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
 describe command(instance_2_cmd) do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| % | root |/) }
+  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service50-single/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service50-single/serverspec/assert_functioning_spec.rb
@@ -25,7 +25,7 @@ def mysql_cmd
   -P 3306 \
   -u root \
   -pilikerandompasswords \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='%';" \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
   --skip-column-names
   EOF
 end
@@ -36,7 +36,7 @@ end
 
 describe command(mysql_cmd) do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| % | root |/) }
+  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service50-single/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service50-single/serverspec/assert_functioning_spec.rb
@@ -18,7 +18,7 @@ def mysqld_bin
   '/usr/sbin/mysqld'
 end
 
-def mysql_cmd
+def mysql_cmd_1
   <<-EOF
   #{mysql_bin} \
   -h 127.0.0.1 \
@@ -30,13 +30,30 @@ def mysql_cmd
   EOF
 end
 
+def mysql_cmd_2
+  <<-EOF
+  #{mysql_bin} \
+  -h 127.0.0.1 \
+  -P 3306 \
+  -u root \
+  -pilikerandompasswords \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
+  --skip-column-names
+  EOF
+end
+
 def mysqld_cmd
   "#{mysqld_bin} --version"
 end
 
-describe command(mysql_cmd) do
+describe command(mysql_cmd_1) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| 127.0.0.1 | root |/) }
+end
+
+describe command(mysql_cmd_2) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/| localhost | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service51-multi/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service51-multi/serverspec/assert_functioning_spec.rb
@@ -19,7 +19,7 @@ def mysqld_bin
   '/usr/sbin/mysqld'
 end
 
-def instance_1_cmd
+def instance_1_cmd_1
   <<-EOF
   #{mysql_bin} \
   -h 127.0.0.1 \
@@ -31,7 +31,19 @@ def instance_1_cmd
   EOF
 end
 
-def instance_2_cmd
+def instance_1_cmd_2
+  <<-EOF
+  #{mysql_bin} \
+  -h 127.0.0.1 \
+  -P 3307 \
+  -u root \
+  -pilikerandompasswords \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
+  --skip-column-names
+  EOF
+end
+
+def instance_2_cmd_1
   <<-EOF
   #{mysql_bin} \
   -h 127.0.0.1 \
@@ -43,18 +55,40 @@ def instance_2_cmd
   EOF
 end
 
+def instance_2_cmd_2
+  <<-EOF
+  #{mysql_bin} \
+  -h 127.0.0.1 \
+  -P 3308 \
+  -u root \
+  -pstring\\ with\\ spaces \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
+  --skip-column-names
+  EOF
+end
+
 def mysqld_cmd
   "#{mysqld_bin} --version"
 end
 
-describe command(instance_1_cmd) do
+describe command(instance_1_cmd_1) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
-describe command(instance_2_cmd) do
+describe command(instance_1_cmd_2) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/| localhost | root |/) }
+end
+
+describe command(instance_2_cmd_1) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| 127.0.0.1 | root |/) }
+end
+
+describe command(instance_2_cmd_2) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/| localhost | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service51-multi/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service51-multi/serverspec/assert_functioning_spec.rb
@@ -26,7 +26,7 @@ def instance_1_cmd
   -P 3307 \
   -u root \
   -pilikerandompasswords \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='%';" \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
   --skip-column-names
   EOF
 end
@@ -38,7 +38,7 @@ def instance_2_cmd
   -P 3308 \
   -u root \
   -pstring\\ with\\ spaces \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='%';" \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
   --skip-column-names
   EOF
 end
@@ -49,12 +49,12 @@ end
 
 describe command(instance_1_cmd) do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| % | root |/) }
+  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
 describe command(instance_2_cmd) do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| % | root |/) }
+  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service51-single/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service51-single/serverspec/assert_functioning_spec.rb
@@ -19,7 +19,7 @@ def mysqld_bin
   '/usr/sbin/mysqld'
 end
 
-def mysql_cmd
+def mysql_cmd_1
   <<-EOF
   #{mysql_bin} \
   -h 127.0.0.1 \
@@ -31,13 +31,30 @@ def mysql_cmd
   EOF
 end
 
+def mysql_cmd_2
+  <<-EOF
+  #{mysql_bin} \
+  -h 127.0.0.1 \
+  -P 3306 \
+  -u root \
+  -pilikerandompasswords \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
+  --skip-column-names
+  EOF
+end
+
 def mysqld_cmd
   "#{mysqld_bin} --version"
 end
 
-describe command(mysql_cmd) do
+describe command(mysql_cmd_1) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| 127.0.0.1 | root |/) }
+end
+
+describe command(mysql_cmd_2) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/| localhost | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service51-single/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service51-single/serverspec/assert_functioning_spec.rb
@@ -26,7 +26,7 @@ def mysql_cmd
   -P 3306 \
   -u root \
   -pilikerandompasswords \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='%';" \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
   --skip-column-names
   EOF
 end
@@ -37,7 +37,7 @@ end
 
 describe command(mysql_cmd) do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| % | root |/) }
+  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service55-multi/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service55-multi/serverspec/assert_functioning_spec.rb
@@ -18,7 +18,7 @@ def mysqld_bin
   '/usr/sbin/mysqld'
 end
 
-def instance_1_cmd
+def instance_1_cmd_1
   <<-EOF
   #{mysql_bin} \
   -h 127.0.0.1 \
@@ -30,7 +30,19 @@ def instance_1_cmd
   EOF
 end
 
-def instance_2_cmd
+def instance_1_cmd_2
+  <<-EOF
+  #{mysql_bin} \
+  -h 127.0.0.1 \
+  -P 3307 \
+  -u root \
+  -pilikerandompasswords \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
+  --skip-column-names
+  EOF
+end
+
+def instance_2_cmd_1
   <<-EOF
   #{mysql_bin} \
   -h 127.0.0.1 \
@@ -42,18 +54,40 @@ def instance_2_cmd
   EOF
 end
 
+def instance_2_cmd_2
+  <<-EOF
+  #{mysql_bin} \
+  -h 127.0.0.1 \
+  -P 3308 \
+  -u root \
+  -pstring\\ with\\ spaces \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
+  --skip-column-names
+  EOF
+end
+
 def mysqld_cmd
   "#{mysqld_bin} --version"
 end
 
-describe command(instance_1_cmd) do
+describe command(instance_1_cmd_1) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
-describe command(instance_2_cmd) do
+describe command(instance_1_cmd_2) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/| localhost | root |/) }
+end
+
+describe command(instance_2_cmd_1) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| 127.0.0.1 | root |/) }
+end
+
+describe command(instance_2_cmd_2) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/| localhost | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service55-multi/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service55-multi/serverspec/assert_functioning_spec.rb
@@ -25,7 +25,7 @@ def instance_1_cmd
   -P 3307 \
   -u root \
   -pilikerandompasswords \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='%';" \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
   --skip-column-names
   EOF
 end
@@ -37,7 +37,7 @@ def instance_2_cmd
   -P 3308 \
   -u root \
   -pstring\\ with\\ spaces \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='%';" \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
   --skip-column-names
   EOF
 end
@@ -48,12 +48,12 @@ end
 
 describe command(instance_1_cmd) do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| % | root |/) }
+  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
 describe command(instance_2_cmd) do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| % | root |/) }
+  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service55-single/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service55-single/serverspec/assert_functioning_spec.rb
@@ -25,7 +25,7 @@ def mysql_cmd
   -P 3306 \
   -u root \
   -pilikerandompasswords \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='%';" \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
   --skip-column-names
   EOF
 end
@@ -36,7 +36,7 @@ end
 
 describe command(mysql_cmd) do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| % | root |/) }
+  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service55-single/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service55-single/serverspec/assert_functioning_spec.rb
@@ -18,7 +18,7 @@ def mysqld_bin
   '/usr/sbin/mysqld'
 end
 
-def mysql_cmd
+def mysql_cmd_1
   <<-EOF
   #{mysql_bin} \
   -h 127.0.0.1 \
@@ -30,13 +30,30 @@ def mysql_cmd
   EOF
 end
 
+def mysql_cmd_2
+  <<-EOF
+  #{mysql_bin} \
+  -h 127.0.0.1 \
+  -P 3306 \
+  -u root \
+  -pilikerandompasswords \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
+  --skip-column-names
+  EOF
+end
+
 def mysqld_cmd
   "#{mysqld_bin} --version"
 end
 
-describe command(mysql_cmd) do
+describe command(mysql_cmd_1) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| 127.0.0.1 | root |/) }
+end
+
+describe command(mysql_cmd_2) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/| localhost | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service56-multi/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service56-multi/serverspec/assert_functioning_spec.rb
@@ -16,7 +16,7 @@ def mysqld_bin
   '/usr/sbin/mysqld'
 end
 
-def instance_1_cmd
+def instance_1_cmd_1
   <<-EOF
   #{mysql_bin} \
   -h 127.0.0.1 \
@@ -28,7 +28,19 @@ def instance_1_cmd
   EOF
 end
 
-def instance_2_cmd
+def instance_1_cmd_2
+  <<-EOF
+  #{mysql_bin} \
+  -h 127.0.0.1 \
+  -P 3307 \
+  -u root \
+  -pilikerandompasswords \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
+  --skip-column-names
+  EOF
+end
+
+def instance_2_cmd_1
   <<-EOF
   #{mysql_bin} \
   -h 127.0.0.1 \
@@ -40,18 +52,40 @@ def instance_2_cmd
   EOF
 end
 
+def instance_2_cmd_2
+  <<-EOF
+  #{mysql_bin} \
+  -h 127.0.0.1 \
+  -P 3308 \
+  -u root \
+  -pstring\\ with\\ spaces \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
+  --skip-column-names
+  EOF
+end
+
 def mysqld_cmd
   "#{mysqld_bin} --version"
 end
 
-describe command(instance_1_cmd) do
+describe command(instance_1_cmd_1) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
-describe command(instance_2_cmd) do
+describe command(instance_1_cmd_2) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/| localhost | root |/) }
+end
+
+describe command(instance_2_cmd_1) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| 127.0.0.1 | root |/) }
+end
+
+describe command(instance_2_cmd_2) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/| localhost | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service56-multi/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service56-multi/serverspec/assert_functioning_spec.rb
@@ -23,7 +23,7 @@ def instance_1_cmd
   -P 3307 \
   -u root \
   -pilikerandompasswords \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='%';" \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
   --skip-column-names
   EOF
 end
@@ -35,7 +35,7 @@ def instance_2_cmd
   -P 3308 \
   -u root \
   -pstring\\ with\\ spaces \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='%';" \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
   --skip-column-names
   EOF
 end
@@ -46,12 +46,12 @@ end
 
 describe command(instance_1_cmd) do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| % | root |/) }
+  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
 describe command(instance_2_cmd) do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| % | root |/) }
+  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service56-single/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service56-single/serverspec/assert_functioning_spec.rb
@@ -23,7 +23,7 @@ def mysql_cmd
   -P 3306 \
   -u root \
   -pilikerandompasswords \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='%';" \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
   --skip-column-names
   EOF
 end
@@ -34,7 +34,7 @@ end
 
 describe command(mysql_cmd) do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| % | root |/) }
+  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service56-single/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service56-single/serverspec/assert_functioning_spec.rb
@@ -16,7 +16,7 @@ def mysqld_bin
   '/usr/sbin/mysqld'
 end
 
-def mysql_cmd
+def mysql_cmd_1
   <<-EOF
   #{mysql_bin} \
   -h 127.0.0.1 \
@@ -28,13 +28,30 @@ def mysql_cmd
   EOF
 end
 
+def mysql_cmd_2
+  <<-EOF
+  #{mysql_bin} \
+  -h 127.0.0.1 \
+  -P 3306 \
+  -u root \
+  -pilikerandompasswords \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
+  --skip-column-names
+  EOF
+end
+
 def mysqld_cmd
   "#{mysqld_bin} --version"
 end
 
-describe command(mysql_cmd) do
+describe command(mysql_cmd_1) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| 127.0.0.1 | root |/) }
+end
+
+describe command(mysql_cmd_2) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/| localhost | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service57-multi/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service57-multi/serverspec/assert_functioning_spec.rb
@@ -16,7 +16,7 @@ def mysqld_bin
   '/usr/sbin/mysqld'
 end
 
-def instance_1_cmd
+def instance_1_cmd_1
   <<-EOF
   #{mysql_bin} \
   -h 127.0.0.1 \
@@ -28,7 +28,19 @@ def instance_1_cmd
   EOF
 end
 
-def instance_2_cmd
+def instance_1_cmd_2
+  <<-EOF
+  #{mysql_bin} \
+  -h 127.0.0.1 \
+  -P 3307 \
+  -u root \
+  -pilikerandompasswords \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
+  --skip-column-names
+  EOF
+end
+
+def instance_2_cmd_1
   <<-EOF
   #{mysql_bin} \
   -h 127.0.0.1 \
@@ -40,18 +52,40 @@ def instance_2_cmd
   EOF
 end
 
+def instance_2_cmd_2
+  <<-EOF
+  #{mysql_bin} \
+  -h 127.0.0.1 \
+  -P 3308 \
+  -u root \
+  -pstring\\ with\\ spaces \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
+  --skip-column-names
+  EOF
+end
+
 def mysqld_cmd
   "#{mysqld_bin} --version"
 end
 
-describe command(instance_1_cmd) do
+describe command(instance_1_cmd_1) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
-describe command(instance_2_cmd) do
+describe command(instance_1_cmd_2) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/| localhost | root |/) }
+end
+
+describe command(instance_2_cmd_1) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| 127.0.0.1 | root |/) }
+end
+
+describe command(instance_2_cmd_2) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/| localhost | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service57-multi/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service57-multi/serverspec/assert_functioning_spec.rb
@@ -16,23 +16,10 @@ def mysqld_bin
   '/usr/sbin/mysqld'
 end
 
-def instance_1_cmd_1
+def instance_1_cmd
   <<-EOF
   #{mysql_bin} \
-  -h 127.0.0.1 \
-  -P 3307 \
-  -u root \
-  -pilikerandompasswords \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
-  --skip-column-names
-  EOF
-end
-
-def instance_1_cmd_2
-  <<-EOF
-  #{mysql_bin} \
-  -h 127.0.0.1 \
-  -P 3307 \
+  -S /var/run/mysql-instance-1/mysqld.sock \
   -u root \
   -pilikerandompasswords \
   -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
@@ -40,23 +27,10 @@ def instance_1_cmd_2
   EOF
 end
 
-def instance_2_cmd_1
+def instance_2_cmd
   <<-EOF
   #{mysql_bin} \
-  -h 127.0.0.1 \
-  -P 3308 \
-  -u root \
-  -pstring\\ with\\ spaces \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
-  --skip-column-names
-  EOF
-end
-
-def instance_2_cmd_2
-  <<-EOF
-  #{mysql_bin} \
-  -h 127.0.0.1 \
-  -P 3308 \
+  -S /var/run/mysql-instance-2/mysqld.sock \
   -u root \
   -pstring\\ with\\ spaces \
   -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
@@ -68,22 +42,12 @@ def mysqld_cmd
   "#{mysqld_bin} --version"
 end
 
-describe command(instance_1_cmd_1) do
-  its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
-end
-
-describe command(instance_1_cmd_2) do
+describe command(instance_1_cmd) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| localhost | root |/) }
 end
 
-describe command(instance_2_cmd_1) do
-  its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
-end
-
-describe command(instance_2_cmd_2) do
+describe command(instance_2_cmd) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| localhost | root |/) }
 end

--- a/test/integration/service57-multi/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service57-multi/serverspec/assert_functioning_spec.rb
@@ -23,7 +23,7 @@ def instance_1_cmd
   -P 3307 \
   -u root \
   -pilikerandompasswords \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='%';" \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
   --skip-column-names
   EOF
 end
@@ -35,7 +35,7 @@ def instance_2_cmd
   -P 3308 \
   -u root \
   -pstring\\ with\\ spaces \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='%';" \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
   --skip-column-names
   EOF
 end
@@ -46,12 +46,12 @@ end
 
 describe command(instance_1_cmd) do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| % | root |/) }
+  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
 describe command(instance_2_cmd) do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| % | root |/) }
+  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service57-single/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service57-single/serverspec/assert_functioning_spec.rb
@@ -23,7 +23,7 @@ def mysql_cmd
   -P 3306 \
   -u root \
   -pilikerandompasswords \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='%';" \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
   --skip-column-names
   EOF
 end
@@ -34,7 +34,7 @@ end
 
 describe command(mysql_cmd) do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| % | root |/) }
+  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service57-single/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service57-single/serverspec/assert_functioning_spec.rb
@@ -16,7 +16,7 @@ def mysqld_bin
   '/usr/sbin/mysqld'
 end
 
-def mysql_cmd
+def mysql_cmd_1
   <<-EOF
   #{mysql_bin} \
   -h 127.0.0.1 \
@@ -28,13 +28,30 @@ def mysql_cmd
   EOF
 end
 
+def mysql_cmd_2
+  <<-EOF
+  #{mysql_bin} \
+  -h 127.0.0.1 \
+  -P 3306 \
+  -u root \
+  -pilikerandompasswords \
+  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
+  --skip-column-names
+  EOF
+end
+
 def mysqld_cmd
   "#{mysqld_bin} --version"
 end
 
-describe command(mysql_cmd) do
+describe command(mysql_cmd_1) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| 127.0.0.1 | root |/) }
+end
+
+describe command(mysql_cmd_2) do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/| localhost | root |/) }
 end
 
 describe command(mysqld_cmd) do

--- a/test/integration/service57-single/serverspec/assert_functioning_spec.rb
+++ b/test/integration/service57-single/serverspec/assert_functioning_spec.rb
@@ -16,23 +16,10 @@ def mysqld_bin
   '/usr/sbin/mysqld'
 end
 
-def mysql_cmd_1
+def mysql_cmd
   <<-EOF
   #{mysql_bin} \
-  -h 127.0.0.1 \
-  -P 3306 \
-  -u root \
-  -pilikerandompasswords \
-  -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='127.0.0.1';" \
-  --skip-column-names
-  EOF
-end
-
-def mysql_cmd_2
-  <<-EOF
-  #{mysql_bin} \
-  -h 127.0.0.1 \
-  -P 3306 \
+  -S /var/run/mysql-default/mysqld.sock \
   -u root \
   -pilikerandompasswords \
   -e "SELECT Host,User FROM mysql.user WHERE User='root' AND Host='localhost';" \
@@ -44,12 +31,7 @@ def mysqld_cmd
   "#{mysqld_bin} --version"
 end
 
-describe command(mysql_cmd_1) do
-  its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/| 127.0.0.1 | root |/) }
-end
-
-describe command(mysql_cmd_2) do
+describe command(mysql_cmd) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/| localhost | root |/) }
 end


### PR DESCRIPTION
This makes sure connections on the machine itself work and is also more secure. Root access to MySQL shouldn't be enabled everywhere by default.