### PR TITLE
Allows you to designate error log location

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -227,6 +227,11 @@ EOSQL
       run_dir
     end
 
+    def error_log
+      return new_resource.error_log if new_resource.error_log
+      error_log
+    end
+    
     def tmp_dir
       '/tmp'
     end

--- a/libraries/resource_mysql_service.rb
+++ b/libraries/resource_mysql_service.rb
@@ -20,7 +20,6 @@ class Chef
       attribute :run_user, kind_of: String, default: 'mysql'
       attribute :socket, kind_of: String, default: nil
       attribute :version, kind_of: String, default: nil
-      attribute :error_log, kind_of: String, default: nil
     end
   end
 end

--- a/libraries/resource_mysql_service.rb
+++ b/libraries/resource_mysql_service.rb
@@ -20,6 +20,7 @@ class Chef
       attribute :run_user, kind_of: String, default: 'mysql'
       attribute :socket, kind_of: String, default: nil
       attribute :version, kind_of: String, default: nil
+      attribute :error_log, kind_of: String, default: nil
     end
   end
 end


### PR DESCRIPTION
You can place the mysql error log in any location you wish by using error_log in mysql_service in wrapper cookbook

mysql_service "test" do
	port "3306"
	version "5.6"
	data_dir "/data/mysql"
	error_log "/logs/mysql/mysql.err"
	socket "/tmp/mysqld.sock"
	initial_root_password "change_me"
	action [:create, :start]
end
