### PR TITLE
option to move error_log directory

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -33,10 +33,6 @@ module MysqlCookbook
       "#{etc_dir}/my.cnf"
     end
 
-    def error_log
-      "#{log_dir}/error.log"
-    end
-
     def etc_dir
       return "/opt/mysql#{pkg_ver_string}/etc/#{mysql_name}" if node['platform_family'] == 'omnios'
       return "#{prefix_dir}/etc/#{mysql_name}" if node['platform_family'] == 'smartos'
@@ -229,7 +225,7 @@ EOSQL
 
     def error_log
       return new_resource.error_log if new_resource.error_log
-      error_log
+      "#{log_dir}/error.log"
     end
     
     def tmp_dir

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -227,6 +227,11 @@ EOSQL
       run_dir
     end
 
+    def error_log
+      return new_resource.error_log if new_resource.error_log
+      error_log
+    end
+    
     def tmp_dir
       '/tmp'
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -47,6 +47,7 @@ module MysqlCookbook
     end
 
     def log_dir
+      return File.dirname(new_resource.error_log) if new_resource.error_log
       return "/var/adm/log/#{mysql_name}" if node['platform_family'] == 'omnios'
       "#{prefix_dir}/var/log/#{mysql_name}"
     end

--- a/libraries/resource_mysql_service.rb
+++ b/libraries/resource_mysql_service.rb
@@ -20,7 +20,6 @@ class Chef
       attribute :run_user, kind_of: String, default: 'mysql'
       attribute :socket, kind_of: String, default: nil
       attribute :version, kind_of: String, default: nil
-      attribute :error_log, kind_of: String, default: nil
     end
   end
 end

--- a/libraries/resource_mysql_service.rb
+++ b/libraries/resource_mysql_service.rb
@@ -20,6 +20,7 @@ class Chef
       attribute :run_user, kind_of: String, default: 'mysql'
       attribute :socket, kind_of: String, default: nil
       attribute :version, kind_of: String, default: nil
+      attribute :error_log, kind_of: String, default: nil
     end
   end
 end


### PR DESCRIPTION
Gives option to move error_log to any directory using mysql_service

mysql_service "test" do
	port "3306"
	version "5.6"
	data_dir "/data/mysql"
	error_log "/logs/mysql/mysql.err"
	socket "/tmp/mysqld.sock"
	initial_root_password "change_me"
	action [:create, :start]
end

