### PR TITLE
Options to move tmpdir, error_log, and pid file

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -33,10 +33,6 @@ module MysqlCookbook
       "#{etc_dir}/my.cnf"
     end
 
-    def error_log
-      "#{log_dir}/error.log"
-    end
-
     def etc_dir
       return "/opt/mysql#{pkg_ver_string}/etc/#{mysql_name}" if node['platform_family'] == 'omnios'
       return "#{prefix_dir}/etc/#{mysql_name}" if node['platform_family'] == 'smartos'
@@ -229,7 +225,7 @@ EOSQL
 
     def error_log
       return new_resource.error_log if new_resource.error_log
-      error_log
+      "#{log_dir}/error.log"
     end
     
     def tmp_dir

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -145,9 +145,6 @@ module MysqlCookbook
         mkdir /tmp/#{mysql_name}
 
         cat > /tmp/#{mysql_name}/my.sql <<-EOSQL
-#DELETE FROM mysql.user ;
-#CREATE USER 'root'@'%' IDENTIFIED BY '#{Shellwords.escape(new_resource.initial_root_password)}' ;
-#GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
 UPDATE mysql.user SET Password=PASSWORD('#{Shellwords.escape(new_resource.initial_root_password)}');
 DELETE FROM mysql.user WHERE user LIKE '';
 DELETE FROM mysql.user WHERE user = 'root' and host NOT IN ('127.0.0.1','localhost');

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -227,6 +227,11 @@ EOSQL
       run_dir
     end
 
+    def error_log
+      return new_resource.error_log if new_resource.error_log
+      error_log
+    end
+    
     def tmp_dir
       '/tmp'
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -47,6 +47,7 @@ module MysqlCookbook
     end
 
     def log_dir
+      return File.dirname(new_resource.error_log) if new_resource.error_log
       return "/var/adm/log/#{mysql_name}" if node['platform_family'] == 'omnios'
       "#{prefix_dir}/var/log/#{mysql_name}"
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -145,11 +145,15 @@ module MysqlCookbook
         mkdir /tmp/#{mysql_name}
 
         cat > /tmp/#{mysql_name}/my.sql <<-EOSQL
-DELETE FROM mysql.user ;
-CREATE USER 'root'@'%' IDENTIFIED BY '#{Shellwords.escape(new_resource.initial_root_password)}' ;
-GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
+#DELETE FROM mysql.user ;
+#CREATE USER 'root'@'%' IDENTIFIED BY '#{Shellwords.escape(new_resource.initial_root_password)}' ;
+#GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
+UPDATE mysql.user SET Password=PASSWORD('#{Shellwords.escape(new_resource.initial_root_password)}');
+DELETE FROM mysql.user WHERE user LIKE '';
+DELETE FROM mysql.user WHERE user = 'root' and host NOT IN ('127.0.0.1','localhost');
+DROP DATABASE test;
+DELETE FROM mysql.db WHERE db LIKE 'test%'
 FLUSH PRIVILEGES;
-DROP DATABASE IF EXISTS test ;
 EOSQL
 
        #{db_init}
@@ -201,6 +205,7 @@ EOSQL
     end
 
     def pid_file
+      return new_resource.pid_file if new_resource.pid_file
       "#{run_dir}/mysqld.pid"
     end
 
@@ -228,8 +233,9 @@ EOSQL
       return new_resource.error_log if new_resource.error_log
       "#{log_dir}/error.log"
     end
-    
-    def tmp_dir
+
+    def tmp_dir 
+      return new_resource.tmp_dir if new_resource.tmp_dir
       '/tmp'
     end
 

--- a/libraries/resource_mysql_service.rb
+++ b/libraries/resource_mysql_service.rb
@@ -21,6 +21,8 @@ class Chef
       attribute :socket, kind_of: String, default: nil
       attribute :version, kind_of: String, default: nil
       attribute :error_log, kind_of: String, default: nil
+      attribute :tmp_dir, kind_of: String, default: nil
+      attribute :pid_file, kind_of: String, default: nil
     end
   end
 end

--- a/libraries/resource_mysql_service.rb
+++ b/libraries/resource_mysql_service.rb
@@ -20,7 +20,6 @@ class Chef
       attribute :run_user, kind_of: String, default: 'mysql'
       attribute :socket, kind_of: String, default: nil
       attribute :version, kind_of: String, default: nil
-      attribute :error_log, kind_of: String, default: nil
     end
   end
 end

--- a/libraries/resource_mysql_service.rb
+++ b/libraries/resource_mysql_service.rb
@@ -20,6 +20,7 @@ class Chef
       attribute :run_user, kind_of: String, default: 'mysql'
       attribute :socket, kind_of: String, default: nil
       attribute :version, kind_of: String, default: nil
+      attribute :error_log, kind_of: String, default: nil
     end
   end
 end


### PR DESCRIPTION
Allows for options to move other directories other than data_dir.
Ignore the init script because @daften is addressing that in #341 