### PR TITLE
Don't force port to be a string

### DIFF
--- a/libraries/resource_mysql_service.rb
+++ b/libraries/resource_mysql_service.rb
@@ -15,7 +15,7 @@ class Chef
       attribute :package_name, kind_of: String, default: nil
       attribute :package_version, kind_of: String, default: nil
       attribute :bind_address, kind_of: String, default: nil
-      attribute :port, kind_of: String, default: '3306'
+      attribute :port, kind_of: [String, Integer], default: '3306'
       attribute :run_group, kind_of: String, default: 'mysql'
       attribute :run_user, kind_of: String, default: 'mysql'
       attribute :socket, kind_of: String, default: nil


### PR DESCRIPTION
Seems sensible to allow it to be a fixnum as well, and just convert