### PR TITLE
allow option to move tmpdir, log-error, and pid-file and fix init script to drop test schema permissions

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -171,7 +171,7 @@ UPDATE mysql.user SET #{password_column_name}=PASSWORD('#{root_password}')#{pass
 DELETE FROM mysql.user WHERE USER LIKE '';
 DELETE FROM mysql.user WHERE user = 'root' and host NOT IN ('127.0.0.1', 'localhost');
 FLUSH PRIVILEGES;
-DELETE FROM mysql.db WHERE db LIKE 'test%'
+DELETE FROM mysql.db WHERE db LIKE 'test%';
 DROP DATABASE IF EXISTS test ;
 EOSQL
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -34,6 +34,7 @@ module MysqlCookbook
     end
 
     def error_log
+      return new_resource.error_log if new_resource.error_log
       "#{log_dir}/error.log"
     end
 
@@ -223,6 +224,7 @@ EOSQL
     end
 
     def pid_file
+      return new_resource.pid_file if new_resource.pid_file
       "#{run_dir}/mysqld.pid"
     end
 
@@ -247,6 +249,7 @@ EOSQL
     end
 
     def tmp_dir
+      return new_resource.tmp_dir if new_resource.tmp_dir
       '/tmp'
     end
 

--- a/libraries/resource_mysql_service.rb
+++ b/libraries/resource_mysql_service.rb
@@ -22,6 +22,9 @@ class Chef
       attribute :run_user, kind_of: String, default: 'mysql'
       attribute :socket, kind_of: String, default: nil
       attribute :version, kind_of: String, default: nil
+      attribute :error_log, kind_of: String, default: nil
+      attribute :tmp_dir, kind_of: String, default: nil
+      attribute :pid_file, kind_of: String, default: nil
     end
   end
 end


### PR DESCRIPTION
These changes will allow for the user to move tmpdir, log-error, and pid-file to any other location than the cookbook default. 
Last a semicolon was missing from the init script that prevented the permissions for the test schema from being dropped. 