### PR TITLE
Adding support for Amazon Linux 2015.09

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -328,6 +328,14 @@ EOSQL
         @pkginfo.set['rhel']['2015.03']['5.6']['server_package'] = 'mysql-community-server'
         @pkginfo.set['rhel']['2015.03']['5.7']['client_package'] = %w(mysql-community-client mysql-community-devel)
         @pkginfo.set['rhel']['2015.03']['5.7']['server_package'] = 'mysql-community-server'
+        @pkginfo.set['rhel']['2015.09']['5.1']['server_package'] = %w(mysql51 mysql51-devel)
+        @pkginfo.set['rhel']['2015.09']['5.1']['server_package'] = 'mysql51-server'
+        @pkginfo.set['rhel']['2015.09']['5.5']['client_package'] = %w(mysql-community-client mysql-community-devel)
+        @pkginfo.set['rhel']['2015.09']['5.5']['server_package'] = 'mysql-community-server'
+        @pkginfo.set['rhel']['2015.09']['5.6']['client_package'] = %w(mysql-community-client mysql-community-devel)
+        @pkginfo.set['rhel']['2015.09']['5.6']['server_package'] = 'mysql-community-server'
+        @pkginfo.set['rhel']['2015.09']['5.7']['client_package'] = %w(mysql-community-client mysql-community-devel)
+        @pkginfo.set['rhel']['2015.09']['5.7']['server_package'] = 'mysql-community-server'
         @pkginfo.set['rhel']['5']['5.0']['client_package'] = %w(mysql mysql-devel)
         @pkginfo.set['rhel']['5']['5.0']['server_package'] = 'mysql-server'
         @pkginfo.set['rhel']['5']['5.1']['client_package'] = %w(mysql51-mysql)


### PR DESCRIPTION
I believe this giant array of platforms/versions is somewhat brittle, especially in the case of Amazon Linux since a major release arrives every six months.  Is it possible that handling this can be added to a routine check list for maintainers of the cookbook so the community doesn't catch this issue?  Alternatively, special handling for the versioning in Amazon Linux could be added so that the cookbook doesn't fail every six months.

Thanks!