### PR TITLE
Adding umask to bash resource that sets root password

### DIFF
--- a/libraries/provider_mysql_service_base.rb
+++ b/libraries/provider_mysql_service_base.rb
@@ -144,6 +144,7 @@ class Chef
         # initialize database and create initial records
         bash "#{new_resource.name} :create initial records" do
           code init_records_script
+          umask '022'
           returns [0, 1, 2] # facepalm
           not_if "/usr/bin/test -f #{parsed_data_dir}/mysql/user.frm"
           action :run


### PR DESCRIPTION
On systems that have a different default umask, the bash resource that sets the root password will not be able to run because it puts a script into /tmp with permissions that do not allow mysqld_safe to access the script.

This change ensures that the /tmp script is written with read and execute permissions for all users.