### PR TITLE
Only create a link if we know that mysql_install_db will be run

### DIFF
--- a/libraries/provider_mysql_service_base.rb
+++ b/libraries/provider_mysql_service_base.rb
@@ -72,6 +72,7 @@ class Chef
           target_file "#{prefix_dir}/usr/share/my-default.cnf"
           to "#{etc_dir}/my.cnf"
           action :create
+          not_if "/usr/bin/test -f #{parsed_data_dir}/mysql/user.frm"
         end
 
         # Support directories


### PR DESCRIPTION
Having multiple instances of mysql means that on each run this link flips over
to each instance.
Since we get notifications of changes on a box, I'd like this to stop.