### PR TITLE
Adding support for Amazon Linux 2016.03

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -336,6 +336,14 @@ EOSQL
         @pkginfo.set['rhel']['2015.09']['5.6']['server_package'] = 'mysql-community-server'
         @pkginfo.set['rhel']['2015.09']['5.7']['client_package'] = %w(mysql-community-client mysql-community-devel)
         @pkginfo.set['rhel']['2015.09']['5.7']['server_package'] = 'mysql-community-server'
+        @pkginfo.set['rhel']['2016.03']['5.1']['server_package'] = %w(mysql51 mysql51-devel)
+        @pkginfo.set['rhel']['2016.03']['5.1']['server_package'] = 'mysql51-server'
+        @pkginfo.set['rhel']['2016.03']['5.5']['client_package'] = %w(mysql-community-client mysql-community-devel)
+        @pkginfo.set['rhel']['2016.03']['5.5']['server_package'] = 'mysql-community-server'
+        @pkginfo.set['rhel']['2016.03']['5.6']['client_package'] = %w(mysql-community-client mysql-community-devel)
+        @pkginfo.set['rhel']['2016.03']['5.6']['server_package'] = 'mysql-community-server'
+        @pkginfo.set['rhel']['2016.03']['5.7']['client_package'] = %w(mysql-community-client mysql-community-devel)
+        @pkginfo.set['rhel']['2016.03']['5.7']['server_package'] = 'mysql-community-server'
         @pkginfo.set['rhel']['5']['5.0']['client_package'] = %w(mysql mysql-devel)
         @pkginfo.set['rhel']['5']['5.0']['server_package'] = 'mysql-server'
         @pkginfo.set['rhel']['5']['5.1']['client_package'] = %w(mysql51-mysql)


### PR DESCRIPTION
Addresses #403 

Again, this is a temporary fix.  #383 needs to be addressed.  Amazon Linux can't continue to fail every six months with this cookbook.