### PR TITLE
Fix <action :delete> for mysql_config.

### DIFF
--- a/libraries/provider_mysql_config.rb
+++ b/libraries/provider_mysql_config.rb
@@ -49,8 +49,8 @@ class Chef
       end
 
       action :delete do
-        file "#{new_resource.name} :delete #{include_dir}/#{new_resource.config_name}.conf" do
-          path "#{include_dir}/#{new_resource.config_name}.conf"
+        file "#{new_resource.name} :delete #{include_dir}/#{new_resource.config_name}.cnf" do
+          path "#{include_dir}/#{new_resource.config_name}.cnf"
           action :delete
         end
       end


### PR DESCRIPTION
I tripped over that issue the other day. I had created something like:
<if 'server-id' in node['mysql']['config'] create a config file, else delete it>.
Creation works nicely, but deleting the config didn't work, which was especially
fun because the mysqld refused to start with that config, so everything went
belly up :)

Figures, the problem is that the template in the :create-action appends the
extension ".cnf" to the configuration name, but the :delete-action appends the
extension ".conf" to the configuration name.

As far as I can see, there are no tests for the delete action, so I don't think
I broke tests.
Style checks still run properly..