### PR TITLE
Tetha ubuntu and svm test fixes

### DIFF
--- a/libraries/provider_mysql_service_smf.rb
+++ b/libraries/provider_mysql_service_smf.rb
@@ -5,7 +5,7 @@ class Chef
       # to how we handle systemd on linux
       if defined?(provides) # foodcritic ~FC023
         provides :mysql_service, os: %w(solaris2 omnios smartos openindiana opensolaris nexentacore) do
-          File.exist?('/usr/sbin/svccfg')
+          ::File.exist?('/usr/sbin/svccfg')
         end
       end
 

--- a/spec/mysql_service/debian/property_test_spec.rb
+++ b/spec/mysql_service/debian/property_test_spec.rb
@@ -43,6 +43,10 @@ EOF
     stub_command('/usr/bin/test -f /var/lib/mysql-default/mysql/user.frm').and_return(true)
   end
 
+  before do
+    allow(Chef::Platform::ServiceHelpers).to receive(:service_resource_providers).and_return([:ubuntu, :upstart])
+  end
+
   # Resource in mysql_service_test::single
   context 'compiling the test recipe' do
     it 'creates mysql_service[default]' do

--- a/spec/mysql_service/debian/ubuntu_1004_service_51_multi_spec.rb
+++ b/spec/mysql_service/debian/ubuntu_1004_service_51_multi_spec.rb
@@ -24,6 +24,10 @@ describe 'mysql_service_test::single on ubuntu-10.04' do
     stub_command('/usr/bin/test -f /data/instance-2/mysql/user.frm').and_return(true)
   end
 
+  before do
+    allow(Chef::Platform::ServiceHelpers).to receive(:service_resource_providers).and_return([:ubuntu, :upstart])
+  end
+
   #
   # Resource in mysql_service_test::single
   #

--- a/spec/mysql_service/debian/ubuntu_1004_service_51_single_spec.rb
+++ b/spec/mysql_service/debian/ubuntu_1004_service_51_single_spec.rb
@@ -15,6 +15,10 @@ describe 'mysql_service_test::single on ubuntu-10.04' do
     stub_command('/usr/bin/test -f /var/lib/mysql-default/mysql/user.frm').and_return(true)
   end
 
+  before do
+    allow(Chef::Platform::ServiceHelpers).to receive(:service_resource_providers).and_return([:ubuntu, :upstart])
+  end
+
   # Resource in mysql_service_test::single
   context 'compiling the test recipe' do
     it 'creates mysql_service[default]' do

--- a/spec/mysql_service/debian/ubuntu_1204_service_55_multi_spec.rb
+++ b/spec/mysql_service/debian/ubuntu_1204_service_55_multi_spec.rb
@@ -24,6 +24,10 @@ describe 'mysql_service_test::single on ubuntu-12.04' do
     stub_command('/usr/bin/test -f /data/instance-2/mysql/user.frm').and_return(true)
   end
 
+  before do
+    allow(Chef::Platform::ServiceHelpers).to receive(:service_resource_providers).and_return([:ubuntu, :upstart])
+  end
+
   #
   # Resource in mysql_service_test::single
   #

--- a/spec/mysql_service/debian/ubuntu_1204_service_55_single_spec.rb
+++ b/spec/mysql_service/debian/ubuntu_1204_service_55_single_spec.rb
@@ -15,6 +15,10 @@ describe 'mysql_service_test::single on ubuntu-12.04' do
     stub_command('/usr/bin/test -f /var/lib/mysql-default/mysql/user.frm').and_return(true)
   end
 
+  before do
+    allow(Chef::Platform::ServiceHelpers).to receive(:service_resource_providers).and_return([:ubuntu, :upstart])
+  end
+
   # Resource in mysql_service_test::single
   context 'compiling the test recipe' do
     it 'creates mysql_service[default]' do

--- a/spec/mysql_service/debian/ubuntu_1404_service_55_multi_spec.rb
+++ b/spec/mysql_service/debian/ubuntu_1404_service_55_multi_spec.rb
@@ -24,6 +24,10 @@ describe 'mysql_service_test::single on ubuntu-14.04' do
     stub_command('/usr/bin/test -f /data/instance-2/mysql/user.frm').and_return(true)
   end
 
+  before do
+    allow(Chef::Platform::ServiceHelpers).to receive(:service_resource_providers).and_return([:ubuntu, :upstart])
+  end
+
   #
   # Resource in mysql_service_test::single
   #

--- a/spec/mysql_service/debian/ubuntu_1404_service_55_single_spec.rb
+++ b/spec/mysql_service/debian/ubuntu_1404_service_55_single_spec.rb
@@ -15,6 +15,10 @@ describe 'mysql_service_test::single on ubuntu-14.04' do
     stub_command('/usr/bin/test -f /var/lib/mysql-default/mysql/user.frm').and_return(true)
   end
 
+  before do
+    allow(Chef::Platform::ServiceHelpers).to receive(:service_resource_providers).and_return([:ubuntu, :upstart])
+  end
+
   # Resource in mysql_service_test::single
   context 'compiling the test recipe' do
     it 'creates mysql_service[default]' do

--- a/spec/mysql_service/debian/ubuntu_1404_service_56_multi_spec.rb
+++ b/spec/mysql_service/debian/ubuntu_1404_service_56_multi_spec.rb
@@ -24,6 +24,10 @@ describe 'mysql_service_test::single on ubuntu-14.04' do
     stub_command('/usr/bin/test -f /data/instance-2/mysql/user.frm').and_return(true)
   end
 
+  before do
+    allow(Chef::Platform::ServiceHelpers).to receive(:service_resource_providers).and_return([:ubuntu, :upstart])
+  end
+
   #
   # Resource in mysql_service_test::single
   #

--- a/spec/mysql_service/debian/ubuntu_1404_service_56_single_spec.rb
+++ b/spec/mysql_service/debian/ubuntu_1404_service_56_single_spec.rb
@@ -15,6 +15,10 @@ describe 'mysql_service_test::single on ubuntu-14.04' do
     stub_command('/usr/bin/test -f /var/lib/mysql-default/mysql/user.frm').and_return(true)
   end
 
+  before do
+    allow(Chef::Platform::ServiceHelpers).to receive(:service_resource_providers).and_return([:ubuntu, :upstart])
+  end
+
   # Resource in mysql_service_test::single
   context 'compiling the test recipe' do
     it 'creates mysql_service[default]' do


### PR DESCRIPTION
Hey,

I noticed your tests are not all working at the moment

I've put some work into the tests and the ubuntu-tests should work just the same as the redhat and centos tests, they were just missing a few stubs. 

There also was a simple issue in a provider that used File instead of ::File and pretty much crashed all tests, but since that was the classical File.exist? call, I've just changed that. 

Now with the other tests, I'm not sure if I can easily fix them, since I'd need to start stubbing in ::File and I'm not sure if I want that. :(