### PR TITLE
Updated apparmor config to allow read & write to sock.lock file

### DIFF
--- a/templates/default/apparmor/usr.sbin.mysqld.erb
+++ b/templates/default/apparmor/usr.sbin.mysqld.erb
@@ -35,8 +35,10 @@
   /var/log/mysql/* rw,
   /var/run/mysqld/mysqld.pid rw,
   /var/run/mysqld/mysqld.sock w,
+  /var/run/mysqld/mysqld.sock.lock rw,
   /run/mysqld/mysqld.pid rw,
   /run/mysqld/mysqld.sock w,
+  /run/mysqld/mysqld.sock.lock rw,
 
   /sys/devices/system/cpu/ r,
 


### PR DESCRIPTION
### Description

This change will allow apparmor to not fail with ubutun 12.04 and mysql 5.7 as with mysql 5.7, it needs to create a lock file to create socket files.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


