### PR TITLE
Adding some versions for packages for amazon.

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -166,6 +166,11 @@ module MysqlCookbook
       return '5.6.29-2.el7' if major_version == '5.6' && el7?
       return '5.7.11-1.el7' if major_version == '5.7' && el7?
 
+      # amazon
+      return '5.5.48-2.el6' if major_version == '5.5' && amazon?
+      return '5.6.31-2.el6' if major_version == '5.6' && amazon?
+      return '5.7.11-1.el6' if major_version == '5.7' && amazon?
+
       # N-1 fedora
       return '5.6.31-1.fc23' if major_version == '5.6' && fc23?
       return '5.7.13-1.fc23' if major_version == '5.7' && fc23?

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Provides mysql_service, mysql_config, and mysql_client resources'
-version '8.0.1'
+version '8.0.2'
 
 supports 'amazon'
 supports 'redhat'


### PR DESCRIPTION
### Description

We add some sensible Amazon linux versions to the helper so we can converge.

### Issues Resolved
    
    RuntimeError
    ------------
    mysql_server_installation_package[default] (/var/chef/cache/cookbooks/mysql/libraries/mysql_service.rb line 36) had an error: RuntimeError: No package version found for version 5.6 on amazon 2016.03. Aborting.
    
### Check List

I tested this fix on my own deployment.

