### PR TITLE
Fix a typo in mysql_service for pkg install

### DIFF
--- a/libraries/mysql_service.rb
+++ b/libraries/mysql_service.rb
@@ -35,7 +35,7 @@ module MysqlCookbook
         when 'auto'
           install = mysql_server_installation(name, &block)
         when 'package'
-          install = mysql_server_installation_packate(name, &block)
+          install = mysql_server_installation_package(name, &block)
         when 'none'
           Chef::Log.info('Skipping Mysql installation. Assuming it was handled previously.')
           return


### PR DESCRIPTION
### Description

Fixes a typo in `mysql_service` when `install_method == 'package'`

### Issues Resolved

None

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD