### PR TITLE
add mysql_name variable to the apparmor instance template

### DIFF
--- a/libraries/mysql_service_base.rb
+++ b/libraries/mysql_service_base.rb
@@ -185,7 +185,10 @@ module MysqlCookbook
               owner 'root'
               group 'root'
               mode '0644'
-              variables(config: new_resource)
+              variables(
+                config: new_resource,
+                mysql_name: mysql_name
+              )
               action :create
               notifies :restart, "service[#{instance} apparmor]", :immediately
             end


### PR DESCRIPTION
### Description

`mysql_name` template variable was not used in the apparmor instance resource therefore apparmor config was not appropriate which prevented mysqld to read the config file. It wasn't an issue on Ubuntu 14 because AppArmor config was in `complain` mode unlike in Ubuntu 16 which used `enforce` by default. 

### Issues Resolved

https://github.com/chef-cookbooks/mysql/issues/440

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

