### PR TITLE
fix mysql service hang on Ubuntu

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -178,10 +178,10 @@ module MysqlCookbook
       return '5.5.49-0+deb8u1' if major_version == '5.5' && jessie?
 
       # ubuntu
-      return '5.5.49-0ubuntu0.12.04.1' if major_version == '5.5' && precise?
-      return '5.5.49-0ubuntu0.14.04.1' if major_version == '5.5' && trusty?
-      return '5.6.30-0ubuntu0.14.04.1' if major_version == '5.6' && trusty?
-      return '5.7.12-0ubuntu1.1' if major_version == '5.7' && xenial?
+      return '5.5.50-0ubuntu0.12.04.1' if major_version == '5.5' && precise?
+      return '5.5.50-0ubuntu0.14.04.1' if major_version == '5.5' && trusty?
+      return '5.6.31-0ubuntu0.14.04.2' if major_version == '5.6' && trusty?
+      return '5.7.13-0ubuntu0.16.04.2' if major_version == '5.7' && xenial?
 
       # suse
       return '5.6.30-2.20.2' if major_version == '5.6' && opensuse?

--- a/libraries/mysql_service_manager_systemd.rb
+++ b/libraries/mysql_service_manager_systemd.rb
@@ -29,8 +29,8 @@ module MysqlCookbook
       create_system_user
       stop_system_service
       create_config
-      initialize_database
       configure_apparmor
+      initialize_database
     end
 
     action :start do

--- a/libraries/mysql_service_manager_upstart.rb
+++ b/libraries/mysql_service_manager_upstart.rb
@@ -8,8 +8,8 @@ module MysqlCookbook
       create_system_user
       stop_system_service
       create_config
-      initialize_database
       configure_apparmor
+      initialize_database
     end
 
     action :start do

--- a/spec/mysql_server_installation_package_spec.rb
+++ b/spec/mysql_server_installation_package_spec.rb
@@ -190,7 +190,7 @@ describe 'mysql_test::installation_server' do
       expect(installation_server_package_ubuntu_1204).to install_mysql_server_installation_package('default').with(
         version: '5.5',
         package_name: 'mysql-server-5.5',
-        package_version: '5.5.49-0ubuntu0.12.04.1'
+        package_version: '5.5.50-0ubuntu0.12.04.1'
       )
     end
   end
@@ -202,7 +202,7 @@ describe 'mysql_test::installation_server' do
       expect(installation_server_package_ubuntu_1404).to install_mysql_server_installation_package('default').with(
         version: '5.5',
         package_name: 'mysql-server-5.5',
-        package_version: '5.5.49-0ubuntu0.14.04.1'
+        package_version: '5.5.50-0ubuntu0.14.04.1'
       )
     end
   end
@@ -214,7 +214,7 @@ describe 'mysql_test::installation_server' do
       expect(installation_server_package_ubuntu_1404).to install_mysql_server_installation_package('default').with(
         version: '5.6',
         package_name: 'mysql-server-5.6',
-        package_version: '5.6.30-0ubuntu0.14.04.1'
+        package_version: '5.6.31-0ubuntu0.14.04.2'
       )
     end
   end
@@ -226,7 +226,7 @@ describe 'mysql_test::installation_server' do
       expect(installation_server_package_ubuntu_1604).to install_mysql_server_installation_package('default').with(
         version: '5.7',
         package_name: 'mysql-server-5.7',
-        package_version: '5.7.12-0ubuntu1.1'
+        package_version: '5.7.13-0ubuntu1.1'
       )
     end
   end


### PR DESCRIPTION
### Description

Change the execution order of AppArmor config creation and MySQL database initialization. By default the cookbook tries to initialize the database but AppArmor will prevent this because it's configuration is not yet updated with the instance details. The cookbook does not fail at this point but moves forward in the execution and hangs at service start.

Moving the AppArmor configuration first will create the configuration to allow mysqld to access it's config file and the initialization can succeed. 

### Issues Resolved
https://github.com/chef-cookbooks/mysql/issues/452

Works only if the following PRs are merged: 
https://github.com/chef-cookbooks/mysql/pull/451
https://github.com/chef-cookbooks/mysql/pull/450

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
