### PR TITLE
Update permission for my.conf.erb to 0700 from 0600

### DIFF
--- a/libraries/mysql_service_base.rb
+++ b/libraries/mysql_service_base.rb
@@ -100,7 +100,7 @@ module MysqlCookbook
           cookbook 'mysql'
           owner run_user
           group run_group
-          mode '0600'
+          mode '0700'
           variables(config: new_resource)
           action :create
         end


### PR DESCRIPTION
### Description

Permission to my.conf.erb has been update to 0700 from 0600 to allow user to execute ```my.conf``` file.

### Issues Resolved

#461 

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


