### PR TITLE
Bump debian version

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -179,8 +179,8 @@ module MysqlCookbook
       return '5.7.13-1.fc24' if major_version == '5.7' && fc24?
 
       # debian
-      return '5.5.49-0+deb7u1' if major_version == '5.5' && wheezy?
-      return '5.5.49-0+deb8u1' if major_version == '5.5' && jessie?
+      return '5.5.50-0+deb7u1' if major_version == '5.5' && wheezy?
+      return '5.5.50-0+deb8u1' if major_version == '5.5' && jessie?
 
       # ubuntu
       return '5.5.50-0ubuntu0.12.04.1' if major_version == '5.5' && precise?


### PR DESCRIPTION
### Description

Bump debian package version.

Is there a reason why this version is hardcoded?

### Issues Resolved

```
        ================================================================================
        Error executing action `install` on resource 'apt_package[mysql-client-5.5]'
        ================================================================================
        
        Mixlib::ShellOut::ShellCommandFailed
        ------------------------------------
        Expected process to exit with [0], but received '100'
        ---- Begin output of apt-get -q -y install mysql-client-5.5=5.5.49-0+deb8u1 ----
        STDOUT: Reading package lists...
        Building dependency tree...
        Reading state information...
        The following packages will be REMOVED:
          mysql-server-5.5
        The following packages will be DOWNGRADED:
          mysql-client-5.5
        0 upgraded, 0 newly installed, 1 downgraded, 1 to remove and 0 not upgraded.
        Need to get 0 B/1667 kB of archives.
        After this operation, 32.4 MB disk space will be freed.
        STDERR: E: There are problems and -y was used without --force-yes
        ---- End output of apt-get -q -y install mysql-client-5.5=5.5.49-0+deb8u1 ----
        Ran apt-get -q -y install mysql-client-5.5=5.5.49-0+deb8u1 returned 100
```

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

