### PR TITLE
[GH 390] Fix incorrect escaping of initial_root_password

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -270,13 +270,17 @@ module MysqlCookbook
     end
 
     def init_records_script
+      # Note: shell-escaping passwords in a SQL file may cause corruption - eg
+      # mysql will read \& as &, but \% as \%. Just escape bare-minimum \ and '
+      sql_escaped_password = root_password.gsub('\\') { '\\\\' }.gsub("'") { '\\\'' }
+
       <<-EOS
         set -e
         rm -rf /tmp/#{mysql_name}
         mkdir /tmp/#{mysql_name}
 
-        cat > /tmp/#{mysql_name}/my.sql <<-EOSQL
-UPDATE mysql.user SET #{password_column_name}=PASSWORD('#{root_password}')#{password_expired} WHERE user = 'root';
+        cat > /tmp/#{mysql_name}/my.sql <<-'EOSQL'
+UPDATE mysql.user SET #{password_column_name}=PASSWORD('#{sql_escaped_password}')#{password_expired} WHERE user = 'root';
 DELETE FROM mysql.user WHERE USER LIKE '';
 DELETE FROM mysql.user WHERE user = 'root' and host NOT IN ('127.0.0.1', 'localhost');
 FLUSH PRIVILEGES;
@@ -304,7 +308,7 @@ EOSQL
         Chef::Log.info('Root password is empty')
         return ''
       end
-      Shellwords.escape(initial_root_password)
+      initial_root_password
     end
 
     def password_expired

--- a/test/cookbooks/mysql_test/libraries/helpers.rb
+++ b/test/cookbooks/mysql_test/libraries/helpers.rb
@@ -4,7 +4,7 @@ require 'chef/mixin/shell_out'
 require 'shellwords'
 include Chef::Mixin::ShellOut
 
-def start_slave_1
+def start_slave_1(root_pass)
   query = ' CHANGE MASTER TO'
   query << " MASTER_HOST='127.0.0.1',"
   query << " MASTER_USER='repl',"
@@ -12,10 +12,10 @@ def start_slave_1
   query << ' MASTER_PORT=3306,'
   query << " MASTER_LOG_POS=#{::File.open('/root/position').read.chomp};"
   query << ' START SLAVE;'
-  shell_out("echo \"#{query}\" | /usr/bin/mysql -u root -h 127.0.0.1 -P3307 -p#{Shellwords.escape('MyPa$$wordHasSpecialChars!')}")
+  shell_out("echo \"#{query}\" | /usr/bin/mysql -u root -h 127.0.0.1 -P3307 -p#{Shellwords.escape(root_pass)}")
 end
 
-def start_slave_2
+def start_slave_2(root_pass)
   query = ' CHANGE MASTER TO'
   query << " MASTER_HOST='127.0.0.1',"
   query << " MASTER_USER='repl',"
@@ -23,5 +23,5 @@ def start_slave_2
   query << ' MASTER_PORT=3306,'
   query << " MASTER_LOG_POS=#{::File.open('/root/position').read.chomp};"
   query << ' START SLAVE;'
-  shell_out("echo \"#{query}\" | /usr/bin/mysql -u root -h 127.0.0.1 -P3308 -p#{Shellwords.escape('MyPa$$wordHasSpecialChars!')}")
+  shell_out("echo \"#{query}\" | /usr/bin/mysql -u root -h 127.0.0.1 -P3308 -p#{Shellwords.escape(root_pass)}")
 end

--- a/test/cookbooks/mysql_test/recipes/smoke.rb
+++ b/test/cookbooks/mysql_test/recipes/smoke.rb
@@ -1,7 +1,7 @@
 require 'shellwords'
 
 # variables
-root_pass = 'MyPa$$wordHasSpecialChars!'
+root_pass = 'MyPa$$word\Has_"Special\'Chars%!'
 
 # master
 mysql_service 'master' do
@@ -111,14 +111,14 @@ end
 
 # start replication on slave-1
 ruby_block 'start_slave_1' do
-  block { start_slave_1 } # libraries/helpers.rb
+  block { start_slave_1(root_pass) } # libraries/helpers.rb
   not_if "/usr/bin/mysql -u root -h 127.0.0.1 -P 3307 -p#{Shellwords.escape(root_pass)} -e 'SHOW SLAVE STATUS\G' | grep Slave_IO_State"
   action :run
 end
 
 # start replication on slave-2
 ruby_block 'start_slave_2' do
-  block { start_slave_2 } # libraries/helpers.rb
+  block { start_slave_2(root_pass) } # libraries/helpers.rb
   not_if "/usr/bin/mysql -u root -h 127.0.0.1 -P 3308 -p#{Shellwords.escape(root_pass)} -e 'SHOW SLAVE STATUS\G' | grep Slave_IO_State"
   action :run
 end

--- a/test/integration/smoke/run_spec.rb
+++ b/test/integration/smoke/run_spec.rb
@@ -7,7 +7,7 @@ def slave_1_cmd
 -h 127.0.0.1 \
 -P 3307 \
 -u root \
--pMyPa\\$\\$word\\\\Has_\\\"Special\\'Chars\\%\\!
+-pMyPa\\$\\$word\\\\Has_\\\"Special\\'Chars\\%\\! \
 -D databass \
 -e "select * from table1"
   EOF
@@ -19,7 +19,7 @@ def slave_2_cmd
 -h 127.0.0.1 \
 -P 3308 \
 -u root \
--pMyPa\\$\\$word\\\\Has_\\\"Special\\'Chars\\%\\!
+-pMyPa\\$\\$word\\\\Has_\\\"Special\\'Chars\\%\\! \
 -D databass \
 -e "select * from table1"
   EOF

--- a/test/integration/smoke/run_spec.rb
+++ b/test/integration/smoke/run_spec.rb
@@ -1,10 +1,13 @@
+# A fully secure / special-charactersy root password:
+# MyPa$$wordHas_"Special\'Chars%!
+
 def slave_1_cmd
   <<-EOF
 /usr/bin/mysql \
 -h 127.0.0.1 \
 -P 3307 \
 -u root \
--pMyPa\\$\\$wordHasSpecialChars\\! \
+-pMyPa\\$\\$word\\\\Has_\\\"Special\\'Chars\\%\\!
 -D databass \
 -e "select * from table1"
   EOF
@@ -16,7 +19,7 @@ def slave_2_cmd
 -h 127.0.0.1 \
 -P 3308 \
 -u root \
--pMyPa\\$\\$wordHasSpecialChars\\! \
+-pMyPa\\$\\$word\\\\Has_\\\"Special\\'Chars\\%\\!
 -D databass \
 -e "select * from table1"
   EOF


### PR DESCRIPTION
### Description

* Return raw password from `root_password` instead of shell-escaping
* SQL-escape the password variable before rendering in `init_records_script`
* Generate the mysql init records script as a quoted heredoc

The previous code was broken for some passwords because it used shell escaping for all values, based on historical behaviour that sent the passwords to mysql on the command line.

It was not updated to take account of the difference between shell and SQL escaping when the cookbook was changed to generate a SQL file and pipe it to mysql.

Mysql usually ignores \ escapes in string literals - `\x` becomes `x`, `\&` becomes `&`. However some - notably `%` - are shell-escaped to `\%` but **stay as `\%` when parsed by mysql**.

See http://dev.mysql.com/doc/refman/5.7/en/string-literals.html

eg: `PASSWORD('pa\$\$w%d')` === `pa$$w%d`

The previous implementation was assigning an incorrect root password on  initialisation, making the instance unusable.

This fixes the issue by only escaping explicit `\` and `'` characters in the password string and rendering in a quoted heredoc so that shell escaping is not required.

Note: this is not a perfect SQL quoting solution - it may break with nulls, tabs, and other non-printable special characters, but it seems reasonable to assume these are unlikely to be used in passwords.

### Issues Resolved

Fixes #390 issues with special characters in root password

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing (modified existing test with more 'special' password)
- [x ] (N/A) New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

