### PR TITLE
Fix packages versions for MySQL 5.6 on Ubuntu 14.04

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -185,7 +185,7 @@ module MysqlCookbook
       # ubuntu
       return '5.5.52-0ubuntu0.12.04.1' if major_version == '5.5' && precise?
       return '5.5.52-0ubuntu0.14.04.1' if major_version == '5.5' && trusty?
-      return '5.6.31-0ubuntu0.14.04.2' if major_version == '5.6' && trusty?
+      return '5.6.33-0ubuntu0.14.04.1' if major_version == '5.6' && trusty?
       return '5.7.15-0ubuntu0.16.04.1' if major_version == '5.7' && xenial?
 
       # suse

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -128,9 +128,9 @@ module MysqlCookbook
       return 'mysql51-mysql' if major_version == '5.1' && el5?
       return 'mysql' if major_version == '5.1' && el6?
       return 'mysql55-mysql' if major_version == '5.5' && el5?
-      return 'mysql-client-5.5' if major_version == '5.5' && node['platform_family'] == 'debian'
-      return 'mysql-client-5.6' if major_version == '5.6' && node['platform_family'] == 'debian'
-      return 'mysql-client-5.7' if major_version == '5.7' && node['platform_family'] == 'debian'
+      return ['mysql-client-5.5', 'libmysqlclient-dev'] if major_version == '5.5' && node['platform_family'] == 'debian'
+      return ['mysql-client-5.6', 'libmysqlclient-dev'] if major_version == '5.6' && node['platform_family'] == 'debian'
+      return ['mysql-client-5.7', 'libmysqlclient-dev'] if major_version == '5.7' && node['platform_family'] == 'debian'
       return 'mysql-community-server-client' if major_version == '5.6' && node['platform_family'] == 'suse'
       'mysql-community-client'
     end
@@ -179,7 +179,7 @@ module MysqlCookbook
       return '5.7.13-1.fc24' if major_version == '5.7' && fc24?
 
       # debian
-      return '5.5.50-0+deb7u1' if major_version == '5.5' && wheezy?
+      return '5.5.47-0+deb7u1' if major_version == '5.5' && wheezy?
       return '5.5.50-0+deb8u1' if major_version == '5.5' && jessie?
 
       # ubuntu

--- a/spec/mysql_client_installation_package_spec.rb
+++ b/spec/mysql_client_installation_package_spec.rb
@@ -204,7 +204,7 @@ describe 'mysql_test::installation_client' do
       expect(installation_client_package_ubuntu_1404).to install_mysql_client_installation_package('default').with(
         version: '5.6',
         package_name: 'mysql-client-5.6',
-        package_version: '5.6.31-0ubuntu0.14.04.2'
+        package_version: '5.6.33-0ubuntu0.14.04.1'
       )
     end
   end

--- a/spec/mysql_client_installation_package_spec.rb
+++ b/spec/mysql_client_installation_package_spec.rb
@@ -155,8 +155,8 @@ describe 'mysql_test::installation_client' do
       installation_client_package_debian_7.converge(described_recipe)
       expect(installation_client_package_debian_7).to install_mysql_client_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-client-5.5',
-        package_version: '5.5.49-0+deb7u1'
+        package_name: ['mysql-client-5.5', 'libmysqlclient-dev'],
+        package_version: '5.5.47-0+deb7u1'
       )
     end
   end
@@ -167,8 +167,8 @@ describe 'mysql_test::installation_client' do
       installation_client_package_debian_8.converge(described_recipe)
       expect(installation_client_package_debian_8).to install_mysql_client_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-client-5.5',
-        package_version: '5.5.49-0+deb8u1'
+        package_name: ['mysql-client-5.5', 'libmysqlclient-dev'],
+        package_version: '5.5.50-0+deb8u1'
       )
     end
   end
@@ -179,7 +179,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_ubuntu_1204.converge(described_recipe)
       expect(installation_client_package_ubuntu_1204).to install_mysql_client_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-client-5.5',
+        package_name: ['mysql-client-5.5', 'libmysqlclient-dev'],
         package_version: '5.5.52-0ubuntu0.12.04.1'
       )
     end
@@ -191,7 +191,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_ubuntu_1404.converge(described_recipe)
       expect(installation_client_package_ubuntu_1404).to install_mysql_client_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-client-5.5',
+        package_name: ['mysql-client-5.5', 'libmysqlclient-dev'],
         package_version: '5.5.52-0ubuntu0.14.04.1'
       )
     end
@@ -203,7 +203,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_ubuntu_1404.converge(described_recipe)
       expect(installation_client_package_ubuntu_1404).to install_mysql_client_installation_package('default').with(
         version: '5.6',
-        package_name: 'mysql-client-5.6',
+        package_name: ['mysql-client-5.6', 'libmysqlclient-dev'],
         package_version: '5.6.33-0ubuntu0.14.04.1'
       )
     end
@@ -215,7 +215,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_ubuntu_1604.converge(described_recipe)
       expect(installation_client_package_ubuntu_1604).to install_mysql_client_installation_package('default').with(
         version: '5.7',
-        package_name: 'mysql-client-5.7',
+        package_name: ['mysql-client-5.7', 'libmysqlclient-dev'],
         package_version: '5.7.15-0ubuntu0.16.04.1'
       )
     end

--- a/spec/mysql_server_installation_package_spec.rb
+++ b/spec/mysql_server_installation_package_spec.rb
@@ -166,7 +166,7 @@ describe 'mysql_test::installation_server' do
       expect(installation_server_package_debian_7).to install_mysql_server_installation_package('default').with(
         version: '5.5',
         package_name: 'mysql-server-5.5',
-        package_version: '5.5.49-0+deb7u1'
+        package_version: '5.5.47-0+deb7u1'
       )
     end
   end
@@ -178,7 +178,7 @@ describe 'mysql_test::installation_server' do
       expect(installation_server_package_debian_8).to install_mysql_server_installation_package('default').with(
         version: '5.5',
         package_name: 'mysql-server-5.5',
-        package_version: '5.5.49-0+deb8u1'
+        package_version: '5.5.50-0+deb8u1'
       )
     end
   end

--- a/spec/mysql_server_installation_package_spec.rb
+++ b/spec/mysql_server_installation_package_spec.rb
@@ -214,7 +214,7 @@ describe 'mysql_test::installation_server' do
       expect(installation_server_package_ubuntu_1404).to install_mysql_server_installation_package('default').with(
         version: '5.6',
         package_name: 'mysql-server-5.6',
-        package_version: '5.6.31-0ubuntu0.14.04.2'
+        package_version: '5.6.33-0ubuntu0.14.04.1'
       )
     end
   end

--- a/test/integration/installation_client_package-50/run_spec.rb
+++ b/test/integration/installation_client_package-50/run_spec.rb
@@ -6,3 +6,7 @@ describe command(mysql_cmd) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/Distrib 5.0/) }
 end
+
+describe command('ldconfig -p | grep -q "libmysqlclient.so$"') do
+  its(:exit_status) { should eq 0 }
+end

--- a/test/integration/installation_client_package-51/run_spec.rb
+++ b/test/integration/installation_client_package-51/run_spec.rb
@@ -7,3 +7,7 @@ describe command(mysql_cmd) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/Distrib 5.1/) }
 end
+
+describe command('ldconfig -p | grep -q "libmysqlclient.so$"') do
+  its(:exit_status) { should eq 0 }
+end

--- a/test/integration/installation_client_package-55/run_spec.rb
+++ b/test/integration/installation_client_package-55/run_spec.rb
@@ -9,3 +9,7 @@ describe command(mysql_cmd) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/Distrib 5.5/) }
 end
+
+describe command('ldconfig -p | grep -q "libmysqlclient.so$"') do
+  its(:exit_status) { should eq 0 }
+end

--- a/test/integration/installation_client_package-56/run_spec.rb
+++ b/test/integration/installation_client_package-56/run_spec.rb
@@ -8,3 +8,7 @@ describe command(mysql_cmd) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/Distrib 5.6/) }
 end
+
+describe command('ldconfig -p | grep -q "libmysqlclient.so$"') do
+  its(:exit_status) { should eq 0 }
+end

--- a/test/integration/installation_client_package-57/run_spec.rb
+++ b/test/integration/installation_client_package-57/run_spec.rb
@@ -6,3 +6,7 @@ describe command(mysql_cmd) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/Distrib 5.7/) }
 end
+
+describe command('ldconfig -p | grep -q "libmysqlclient.so$"') do
+  its(:exit_status) { should eq 0 }
+end


### PR DESCRIPTION
### Description

Package 5.6.31-0ubuntu0.14.04.2 is no more available for Ubuntu 14.04. This PR uses the new version available: 5.6.33-0ubuntu0.14.04.1.

### Issues Resolved

The cookbook mysql raises an error when MySQL 5.6 is installed on Ubuntu 14.04. Now it's fixed.

### Check List
- [X] All tests Ubuntu pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

