### PR TITLE
Drop hardcoded, specific package versions

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -147,54 +147,6 @@ module MysqlCookbook
       'mysql-community-server'
     end
 
-    def default_package_version
-      # el5
-      return '5.0.95-5.el5_9' if major_version == '5.0' && el5?
-      return '5.1.70-1.el5' if major_version == '5.1' && el5?
-      return '5.5.45-1.el5' if major_version == '5.5' && el5?
-      return '5.6.29-2.el5' if major_version == '5.6' && el5?
-      return '5.7.11-1.el5' if major_version == '5.7' && el5?
-
-      # el6
-      return '5.1.73-7.el6' if major_version == '5.1' && el6?
-      return '5.5.48-2.el6' if major_version == '5.5' && el6?
-      return '5.6.29-2.el6' if major_version == '5.6' && el6?
-      return '5.7.11-1.el6' if major_version == '5.7' && el6?
-
-      # el7
-      return '5.5.48-2.el7' if major_version == '5.5' && el7?
-      return '5.6.29-2.el7' if major_version == '5.6' && el7?
-      return '5.7.11-1.el7' if major_version == '5.7' && el7?
-
-      # amazon
-      return '5.5.48-2.el6' if major_version == '5.5' && amazon?
-      return '5.6.31-2.el6' if major_version == '5.6' && amazon?
-      return '5.7.11-1.el6' if major_version == '5.7' && amazon?
-
-      # N-1 fedora
-      return '5.6.31-1.fc23' if major_version == '5.6' && fc23?
-      return '5.7.13-1.fc23' if major_version == '5.7' && fc23?
-
-      return '5.6.31-1.fc24' if major_version == '5.6' && fc24?
-      return '5.7.13-1.fc24' if major_version == '5.7' && fc24?
-
-      # debian
-      return '5.5.50-0+deb7u1' if major_version == '5.5' && wheezy?
-      return '5.5.50-0+deb8u1' if major_version == '5.5' && jessie?
-
-      # ubuntu
-      return '5.5.52-0ubuntu0.12.04.1' if major_version == '5.5' && precise?
-      return '5.5.52-0ubuntu0.14.04.1' if major_version == '5.5' && trusty?
-      return '5.6.31-0ubuntu0.14.04.2' if major_version == '5.6' && trusty?
-      return '5.7.15-0ubuntu0.16.04.1' if major_version == '5.7' && xenial?
-
-      # suse
-      return '5.6.30-2.20.2' if major_version == '5.6' && opensuse?
-      return '5.6.30-16.2' if major_version == '5.6' && opensuseleap?
-
-      raise "No package version found for version #{major_version} on #{node['platform']} #{node['platform_version']}. Aborting."
-    end
-
     def socket_dir
       File.dirname(socket)
     end

--- a/libraries/mysql_client_installation_package.rb
+++ b/libraries/mysql_client_installation_package.rb
@@ -11,7 +11,7 @@ module MysqlCookbook
 
     property :package_name, String, default: lazy { default_client_package_name }, desired_state: false
     property :package_options, [String, nil], desired_state: false
-    property :package_version, [String, nil], default: lazy { default_package_version }, desired_state: false
+    property :package_version, [String, nil], default: nil, desired_state: false
 
     # Actions
     action :create do

--- a/libraries/mysql_server_installation_package.rb
+++ b/libraries/mysql_server_installation_package.rb
@@ -6,7 +6,7 @@ module MysqlCookbook
 
     property :package_name, String, default: lazy { default_server_package_name }, desired_state: false
     property :package_options, [String, nil], desired_state: false
-    property :package_version, [String, nil], default: lazy { default_package_version }, desired_state: false
+    property :package_version, [String, nil], default: nil, desired_state: false
 
     # helper methods
     require_relative 'helpers'

--- a/libraries/mysql_service.rb
+++ b/libraries/mysql_service.rb
@@ -12,7 +12,7 @@ module MysqlCookbook
     property :major_version, String, default: lazy { major_from_full(version) }, desired_state: false
     property :package_name, String, default: lazy { default_package_name }, desired_state: false
     property :package_options, [String, nil], desired_state: false
-    property :package_version, [String, nil], default: lazy { default_package_version }, desired_state: false
+    property :package_version, [String, nil], default: nil, desired_state: false
 
     ################
     # Helper Methods

--- a/spec/mysql_client_installation_package_spec.rb
+++ b/spec/mysql_client_installation_package_spec.rb
@@ -17,8 +17,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_centos_5.converge(described_recipe)
       expect(installation_client_package_centos_5).to install_mysql_client_installation_package('default').with(
         version: '5.0',
-        package_name: 'mysql',
-        package_version: '5.0.95-5.el5_9'
+        package_name: 'mysql'
       )
     end
 
@@ -27,8 +26,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_centos_5.converge(described_recipe)
       expect(installation_client_package_centos_5).to install_mysql_client_installation_package('default').with(
         version: '5.1',
-        package_name: 'mysql51-mysql',
-        package_version: '5.1.70-1.el5'
+        package_name: 'mysql51-mysql'
       )
     end
 
@@ -37,8 +35,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_centos_5.converge(described_recipe)
       expect(installation_client_package_centos_5).to install_mysql_client_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql55-mysql',
-        package_version: '5.5.45-1.el5'
+        package_name: 'mysql55-mysql'
       )
     end
 
@@ -47,8 +44,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_centos_5.converge(described_recipe)
       expect(installation_client_package_centos_5).to install_mysql_client_installation_package('default').with(
         version: '5.6',
-        package_name: 'mysql-community-client',
-        package_version: '5.6.29-2.el5'
+        package_name: 'mysql-community-client'
       )
     end
 
@@ -57,8 +53,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_centos_5.converge(described_recipe)
       expect(installation_client_package_centos_5).to install_mysql_client_installation_package('default').with(
         version: '5.7',
-        package_name: 'mysql-community-client',
-        package_version: '5.7.11-1.el5'
+        package_name: 'mysql-community-client'
       )
     end
   end
@@ -69,8 +64,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_centos_6.converge(described_recipe)
       expect(installation_client_package_centos_6).to install_mysql_client_installation_package('default').with(
         version: '5.1',
-        package_name: 'mysql',
-        package_version: '5.1.73-7.el6'
+        package_name: 'mysql'
       )
     end
 
@@ -79,8 +73,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_centos_6.converge(described_recipe)
       expect(installation_client_package_centos_6).to install_mysql_client_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-community-client',
-        package_version: '5.5.48-2.el6'
+        package_name: 'mysql-community-client'
       )
     end
 
@@ -89,8 +82,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_centos_6.converge(described_recipe)
       expect(installation_client_package_centos_6).to install_mysql_client_installation_package('default').with(
         version: '5.6',
-        package_name: 'mysql-community-client',
-        package_version: '5.6.29-2.el6'
+        package_name: 'mysql-community-client'
       )
     end
 
@@ -99,8 +91,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_centos_6.converge(described_recipe)
       expect(installation_client_package_centos_6).to install_mysql_client_installation_package('default').with(
         version: '5.7',
-        package_name: 'mysql-community-client',
-        package_version: '5.7.11-1.el6'
+        package_name: 'mysql-community-client'
       )
     end
   end
@@ -111,8 +102,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_centos_7.converge(described_recipe)
       expect(installation_client_package_centos_7).to install_mysql_client_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-community-client',
-        package_version: '5.5.48-2.el7'
+        package_name: 'mysql-community-client'
       )
     end
 
@@ -121,8 +111,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_centos_7.converge(described_recipe)
       expect(installation_client_package_centos_7).to install_mysql_client_installation_package('default').with(
         version: '5.6',
-        package_name: 'mysql-community-client',
-        package_version: '5.6.29-2.el7'
+        package_name: 'mysql-community-client'
       )
     end
 
@@ -131,8 +120,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_centos_7.converge(described_recipe)
       expect(installation_client_package_centos_7).to install_mysql_client_installation_package('default').with(
         version: '5.7',
-        package_name: 'mysql-community-client',
-        package_version: '5.7.11-1.el7'
+        package_name: 'mysql-community-client'
       )
     end
   end
@@ -143,8 +131,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_fedora_23.converge(described_recipe)
       expect(installation_client_package_fedora_23).to install_mysql_client_installation_package('default').with(
         version: '5.7',
-        package_name: 'mysql-community-client',
-        package_version: '5.7.13-1.fc23'
+        package_name: 'mysql-community-client'
       )
     end
   end
@@ -155,8 +142,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_debian_7.converge(described_recipe)
       expect(installation_client_package_debian_7).to install_mysql_client_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-client-5.5',
-        package_version: '5.5.49-0+deb7u1'
+        package_name: 'mysql-client-5.5'
       )
     end
   end
@@ -167,8 +153,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_debian_8.converge(described_recipe)
       expect(installation_client_package_debian_8).to install_mysql_client_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-client-5.5',
-        package_version: '5.5.49-0+deb8u1'
+        package_name: 'mysql-client-5.5'
       )
     end
   end
@@ -179,8 +164,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_ubuntu_1204.converge(described_recipe)
       expect(installation_client_package_ubuntu_1204).to install_mysql_client_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-client-5.5',
-        package_version: '5.5.52-0ubuntu0.12.04.1'
+        package_name: 'mysql-client-5.5'
       )
     end
   end
@@ -191,8 +175,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_ubuntu_1404.converge(described_recipe)
       expect(installation_client_package_ubuntu_1404).to install_mysql_client_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-client-5.5',
-        package_version: '5.5.52-0ubuntu0.14.04.1'
+        package_name: 'mysql-client-5.5'
       )
     end
   end
@@ -203,8 +186,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_ubuntu_1404.converge(described_recipe)
       expect(installation_client_package_ubuntu_1404).to install_mysql_client_installation_package('default').with(
         version: '5.6',
-        package_name: 'mysql-client-5.6',
-        package_version: '5.6.31-0ubuntu0.14.04.2'
+        package_name: 'mysql-client-5.6'
       )
     end
   end
@@ -215,8 +197,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_ubuntu_1604.converge(described_recipe)
       expect(installation_client_package_ubuntu_1604).to install_mysql_client_installation_package('default').with(
         version: '5.7',
-        package_name: 'mysql-client-5.7',
-        package_version: '5.7.15-0ubuntu0.16.04.1'
+        package_name: 'mysql-client-5.7'
       )
     end
   end

--- a/spec/mysql_server_installation_package_spec.rb
+++ b/spec/mysql_server_installation_package_spec.rb
@@ -17,8 +17,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_centos_5.converge(described_recipe)
       expect(installation_server_package_centos_5).to install_mysql_server_installation_package('default').with(
         version: '5.0',
-        package_name: 'mysql-server',
-        package_version: '5.0.95-5.el5_9'
+        package_name: 'mysql-server'
       )
     end
 
@@ -27,8 +26,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_centos_5.converge(described_recipe)
       expect(installation_server_package_centos_5).to install_mysql_server_installation_package('default').with(
         version: '5.1',
-        package_name: 'mysql51-mysql-server',
-        package_version: '5.1.70-1.el5'
+        package_name: 'mysql51-mysql-server'
       )
     end
 
@@ -37,8 +35,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_centos_5.converge(described_recipe)
       expect(installation_server_package_centos_5).to install_mysql_server_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql55-mysql-server',
-        package_version: '5.5.45-1.el5'
+        package_name: 'mysql55-mysql-server'
       )
     end
 
@@ -47,8 +44,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_centos_5.converge(described_recipe)
       expect(installation_server_package_centos_5).to install_mysql_server_installation_package('default').with(
         version: '5.6',
-        package_name: 'mysql-community-server',
-        package_version: '5.6.29-2.el5'
+        package_name: 'mysql-community-server'
       )
     end
 
@@ -57,8 +53,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_centos_5.converge(described_recipe)
       expect(installation_server_package_centos_5).to install_mysql_server_installation_package('default').with(
         version: '5.7',
-        package_name: 'mysql-community-server',
-        package_version: '5.7.11-1.el5'
+        package_name: 'mysql-community-server'
       )
     end
   end
@@ -69,8 +64,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_centos_6.converge(described_recipe)
       expect(installation_server_package_centos_6).to install_mysql_server_installation_package('default').with(
         version: '5.1',
-        package_name: 'mysql-server',
-        package_version: '5.1.73-7.el6'
+        package_name: 'mysql-server'
       )
     end
 
@@ -79,8 +73,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_centos_6.converge(described_recipe)
       expect(installation_server_package_centos_6).to install_mysql_server_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-community-server',
-        package_version: '5.5.48-2.el6'
+        package_name: 'mysql-community-server'
       )
     end
 
@@ -89,8 +82,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_centos_6.converge(described_recipe)
       expect(installation_server_package_centos_6).to install_mysql_server_installation_package('default').with(
         version: '5.6',
-        package_name: 'mysql-community-server',
-        package_version: '5.6.29-2.el6'
+        package_name: 'mysql-community-server'
       )
     end
 
@@ -99,8 +91,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_centos_6.converge(described_recipe)
       expect(installation_server_package_centos_6).to install_mysql_server_installation_package('default').with(
         version: '5.7',
-        package_name: 'mysql-community-server',
-        package_version: '5.7.11-1.el6'
+        package_name: 'mysql-community-server'
       )
     end
   end
@@ -111,8 +102,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_centos_7.converge(described_recipe)
       expect(installation_server_package_centos_7).to install_mysql_server_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-community-server',
-        package_version: '5.5.48-2.el7'
+        package_name: 'mysql-community-server'
       )
     end
 
@@ -121,8 +111,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_centos_7.converge(described_recipe)
       expect(installation_server_package_centos_7).to install_mysql_server_installation_package('default').with(
         version: '5.6',
-        package_name: 'mysql-community-server',
-        package_version: '5.6.29-2.el7'
+        package_name: 'mysql-community-server'
       )
     end
 
@@ -131,8 +120,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_centos_7.converge(described_recipe)
       expect(installation_server_package_centos_7).to install_mysql_server_installation_package('default').with(
         version: '5.7',
-        package_name: 'mysql-community-server',
-        package_version: '5.7.11-1.el7'
+        package_name: 'mysql-community-server'
       )
     end
   end
@@ -143,8 +131,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_fedora_23.converge(described_recipe)
       expect(installation_server_package_fedora_23).to install_mysql_server_installation_package('default').with(
         version: '5.6',
-        package_name: 'mysql-community-server',
-        package_version: '5.6.31-1.fc23'
+        package_name: 'mysql-community-server'
       )
     end
 
@@ -153,8 +140,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_fedora_23.converge(described_recipe)
       expect(installation_server_package_fedora_23).to install_mysql_server_installation_package('default').with(
         version: '5.7',
-        package_name: 'mysql-community-server',
-        package_version: '5.7.13-1.fc23'
+        package_name: 'mysql-community-server'
       )
     end
   end
@@ -165,8 +151,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_debian_7.converge(described_recipe)
       expect(installation_server_package_debian_7).to install_mysql_server_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-server-5.5',
-        package_version: '5.5.49-0+deb7u1'
+        package_name: 'mysql-server-5.5'
       )
     end
   end
@@ -177,8 +162,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_debian_8.converge(described_recipe)
       expect(installation_server_package_debian_8).to install_mysql_server_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-server-5.5',
-        package_version: '5.5.49-0+deb8u1'
+        package_name: 'mysql-server-5.5'
       )
     end
   end
@@ -189,8 +173,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_ubuntu_1204.converge(described_recipe)
       expect(installation_server_package_ubuntu_1204).to install_mysql_server_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-server-5.5',
-        package_version: '5.5.52-0ubuntu0.12.04.1'
+        package_name: 'mysql-server-5.5'
       )
     end
   end
@@ -201,8 +184,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_ubuntu_1404.converge(described_recipe)
       expect(installation_server_package_ubuntu_1404).to install_mysql_server_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-server-5.5',
-        package_version: '5.5.52-0ubuntu0.14.04.1'
+        package_name: 'mysql-server-5.5'
       )
     end
   end
@@ -213,8 +195,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_ubuntu_1404.converge(described_recipe)
       expect(installation_server_package_ubuntu_1404).to install_mysql_server_installation_package('default').with(
         version: '5.6',
-        package_name: 'mysql-server-5.6',
-        package_version: '5.6.31-0ubuntu0.14.04.2'
+        package_name: 'mysql-server-5.6'
       )
     end
   end
@@ -225,8 +206,7 @@ describe 'mysql_test::installation_server' do
       installation_server_package_ubuntu_1604.converge(described_recipe)
       expect(installation_server_package_ubuntu_1604).to install_mysql_server_installation_package('default').with(
         version: '5.7',
-        package_name: 'mysql-server-5.7',
-        package_version: '5.7.15-0ubuntu0.16.04.1'
+        package_name: 'mysql-server-5.7'
       )
     end
   end


### PR DESCRIPTION
### Description

This removes the hardcoded package versions, and the default behavior of using these hardcoded versions, in favor of a less fragile method of using the `major_version` to install MySQL.

An operator may still specify a `package_version` if they wish.

### Issues Resolved

* Fixes #484
* Fixes #482
* Fixes #479
* Fixes #476 
* Fixes #472
* Fixes #471
* Fixes #470
* Fixes #436
* Fixes #383

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>