### PR TITLE
    Fix & test issue #457

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -6,4 +6,5 @@ group :integration do
   cookbook 'apt'
   cookbook 'selinux'
   cookbook 'mysql_test', path: 'test/cookbooks/mysql_test'
+  cookbook 'yum'
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -124,15 +124,15 @@ module MysqlCookbook
     end
 
     def default_client_package_name
-      return 'mysql' if major_version == '5.0' && el5?
-      return 'mysql51-mysql' if major_version == '5.1' && el5?
-      return 'mysql' if major_version == '5.1' && el6?
-      return 'mysql55-mysql' if major_version == '5.5' && el5?
+      return ['mysql', 'mysql-devel'] if major_version == '5.0' && el5?
+      return ['mysql51-mysql', 'mysql51-mysql-libs'] if major_version == '5.1' && el5?
+      return ['mysql', 'mysql-devel'] if major_version == '5.1' && el6?
+      return ['mysql55-mysql', 'mysql55-mysql-devel'] if major_version == '5.5' && el5?
       return ['mysql-client-5.5', 'libmysqlclient-dev'] if major_version == '5.5' && node['platform_family'] == 'debian'
       return ['mysql-client-5.6', 'libmysqlclient-dev'] if major_version == '5.6' && node['platform_family'] == 'debian'
       return ['mysql-client-5.7', 'libmysqlclient-dev'] if major_version == '5.7' && node['platform_family'] == 'debian'
       return 'mysql-community-server-client' if major_version == '5.6' && node['platform_family'] == 'suse'
-      'mysql-community-client'
+      ['mysql-community-client', 'mysql-community-devel']
     end
 
     def default_server_package_name

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -128,9 +128,9 @@ module MysqlCookbook
       return 'mysql51-mysql' if major_version == '5.1' && el5?
       return 'mysql' if major_version == '5.1' && el6?
       return 'mysql55-mysql' if major_version == '5.5' && el5?
-      return 'mysql-client-5.5' if major_version == '5.5' && node['platform_family'] == 'debian'
-      return 'mysql-client-5.6' if major_version == '5.6' && node['platform_family'] == 'debian'
-      return 'mysql-client-5.7' if major_version == '5.7' && node['platform_family'] == 'debian'
+      return ['mysql-client-5.5', 'libmysqlclient-dev'] if major_version == '5.5' && node['platform_family'] == 'debian'
+      return ['mysql-client-5.6', 'libmysqlclient-dev'] if major_version == '5.6' && node['platform_family'] == 'debian'
+      return ['mysql-client-5.7', 'libmysqlclient-dev'] if major_version == '5.7' && node['platform_family'] == 'debian'
       return 'mysql-community-server-client' if major_version == '5.6' && node['platform_family'] == 'suse'
       'mysql-community-client'
     end

--- a/libraries/mysql_client_installation_package.rb
+++ b/libraries/mysql_client_installation_package.rb
@@ -9,7 +9,7 @@ module MysqlCookbook
     provides :mysql_client_installation, os: 'linux'
     provides :mysql_client, os: 'linux'
 
-    property :package_name, String, default: lazy { default_client_package_name }, desired_state: false
+    property :package_name, [String, Array], default: lazy { default_client_package_name }, desired_state: false
     property :package_options, [String, nil], desired_state: false
     property :package_version, [String, nil], default: nil, desired_state: false
 

--- a/spec/mysql_client_installation_package_spec.rb
+++ b/spec/mysql_client_installation_package_spec.rb
@@ -142,7 +142,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_debian_7.converge(described_recipe)
       expect(installation_client_package_debian_7).to install_mysql_client_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-client-5.5'
+        package_name: ['mysql-client-5.5', 'libmysqlclient-dev']
       )
     end
   end
@@ -153,7 +153,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_debian_8.converge(described_recipe)
       expect(installation_client_package_debian_8).to install_mysql_client_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-client-5.5'
+        package_name: ['mysql-client-5.5', 'libmysqlclient-dev']
       )
     end
   end
@@ -164,7 +164,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_ubuntu_1204.converge(described_recipe)
       expect(installation_client_package_ubuntu_1204).to install_mysql_client_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-client-5.5'
+        package_name: ['mysql-client-5.5', 'libmysqlclient-dev']
       )
     end
   end
@@ -175,7 +175,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_ubuntu_1404.converge(described_recipe)
       expect(installation_client_package_ubuntu_1404).to install_mysql_client_installation_package('default').with(
         version: '5.5',
-        package_name: 'mysql-client-5.5'
+        package_name: ['mysql-client-5.5', 'libmysqlclient-dev']
       )
     end
   end
@@ -186,7 +186,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_ubuntu_1404.converge(described_recipe)
       expect(installation_client_package_ubuntu_1404).to install_mysql_client_installation_package('default').with(
         version: '5.6',
-        package_name: 'mysql-client-5.6'
+        package_name: ['mysql-client-5.6', 'libmysqlclient-dev']
       )
     end
   end
@@ -197,7 +197,7 @@ describe 'mysql_test::installation_client' do
       installation_client_package_ubuntu_1604.converge(described_recipe)
       expect(installation_client_package_ubuntu_1604).to install_mysql_client_installation_package('default').with(
         version: '5.7',
-        package_name: 'mysql-client-5.7'
+        package_name: ['mysql-client-5.7', 'libmysqlclient-dev']
       )
     end
   end

--- a/test/integration/installation_client_package-50/run_spec.rb
+++ b/test/integration/installation_client_package-50/run_spec.rb
@@ -6,3 +6,7 @@ describe command(mysql_cmd) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/Distrib 5.0/) }
 end
+
+describe command('ldconfig -p | grep -q "libmysqlclient.so$"') do
+  its(:exit_status) { should eq 0 }
+end

--- a/test/integration/installation_client_package-50/run_spec.rb
+++ b/test/integration/installation_client_package-50/run_spec.rb
@@ -10,3 +10,7 @@ end
 describe command('ldconfig -p | grep -q "libmysqlclient.so$"') do
   its(:exit_status) { should eq 0 }
 end
+
+describe file('/usr/include/mysql/mysql.h') do
+  it { should exist }
+end

--- a/test/integration/installation_client_package-51/run_spec.rb
+++ b/test/integration/installation_client_package-51/run_spec.rb
@@ -11,3 +11,7 @@ end
 describe command('ldconfig -p | grep -q "libmysqlclient.so$"') do
   its(:exit_status) { should eq 0 }
 end
+
+describe file('/usr/include/mysql/mysql.h') do
+  it { should exist }
+end

--- a/test/integration/installation_client_package-51/run_spec.rb
+++ b/test/integration/installation_client_package-51/run_spec.rb
@@ -7,3 +7,7 @@ describe command(mysql_cmd) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/Distrib 5.1/) }
 end
+
+describe command('ldconfig -p | grep -q "libmysqlclient.so$"') do
+  its(:exit_status) { should eq 0 }
+end

--- a/test/integration/installation_client_package-55/run_spec.rb
+++ b/test/integration/installation_client_package-55/run_spec.rb
@@ -9,3 +9,7 @@ describe command(mysql_cmd) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/Distrib 5.5/) }
 end
+
+describe command('ldconfig -p | grep -q "libmysqlclient.so$"') do
+  its(:exit_status) { should eq 0 }
+end

--- a/test/integration/installation_client_package-55/run_spec.rb
+++ b/test/integration/installation_client_package-55/run_spec.rb
@@ -13,3 +13,7 @@ end
 describe command('ldconfig -p | grep -q "libmysqlclient.so$"') do
   its(:exit_status) { should eq 0 }
 end
+
+describe file('/usr/include/mysql/mysql.h') do
+  it { should exist }
+end

--- a/test/integration/installation_client_package-56/run_spec.rb
+++ b/test/integration/installation_client_package-56/run_spec.rb
@@ -8,3 +8,7 @@ describe command(mysql_cmd) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/Distrib 5.6/) }
 end
+
+describe command('ldconfig -p | grep -q "libmysqlclient.so$"') do
+  its(:exit_status) { should eq 0 }
+end

--- a/test/integration/installation_client_package-56/run_spec.rb
+++ b/test/integration/installation_client_package-56/run_spec.rb
@@ -12,3 +12,7 @@ end
 describe command('ldconfig -p | grep -q "libmysqlclient.so$"') do
   its(:exit_status) { should eq 0 }
 end
+
+describe file('/usr/include/mysql/mysql.h') do
+  it { should exist }
+end

--- a/test/integration/installation_client_package-57/run_spec.rb
+++ b/test/integration/installation_client_package-57/run_spec.rb
@@ -6,3 +6,7 @@ describe command(mysql_cmd) do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/Distrib 5.7/) }
 end
+
+describe command('ldconfig -p | grep -q "libmysqlclient.so$"') do
+  its(:exit_status) { should eq 0 }
+end

--- a/test/integration/installation_client_package-57/run_spec.rb
+++ b/test/integration/installation_client_package-57/run_spec.rb
@@ -10,3 +10,7 @@ end
 describe command('ldconfig -p | grep -q "libmysqlclient.so$"') do
   its(:exit_status) { should eq 0 }
 end
+
+describe file('/usr/include/mysql/mysql.h') do
+  it { should exist }
+end


### PR DESCRIPTION
### Description

Add package 'libmysqlclient-dev' to list of packages to be installed for some platforms.

### Issues Resolved

Fix issue #457 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

    The library for mysql client is missing for some platforms whereas the
    documentations states "The mysql_client resource manages the MySQL
    client binaries and *development libraries*".

    This change fixes the issue by adding package 'libmysqlclient-dev' to
    list of packages to be installed. I've also added spec test to check
    the library file exists now.

    Signed-off-by: Jean-Pierre Matsumoto <jpmat296@gmail.com>