### PR TITLE
Make test kitchen show deprecation errors

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -8,6 +8,7 @@ transport:
 
 provisioner:
   name: dokken
+  deprecations_as_errors: true
 
 verifier:
   name: inspec

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,6 +5,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  deprecations_as_errors: true
 
 verifier:
   name: inspec

--- a/libraries/mysql_service_manager_upstart.rb
+++ b/libraries/mysql_service_manager_upstart.rb
@@ -68,12 +68,7 @@ module MysqlCookbook
       # http://upstart.ubuntu.com/cookbook/#restart
       service mysql_name do
         provider Chef::Provider::Service::Upstart
-        action :stop
-      end
-
-      service mysql_name do
-        provider Chef::Provider::Service::Upstart
-        action :start
+        action [:stop, :start]
       end
     end
 
@@ -83,12 +78,7 @@ module MysqlCookbook
       # supposed to, so we need to actually restart the service.
       service mysql_name do
         provider Chef::Provider::Service::Upstart
-        action :stop
-      end
-
-      service mysql_name do
-        provider Chef::Provider::Service::Upstart
-        action :start
+        action [:stop, :start]
       end
     end
 


### PR DESCRIPTION
### Description

Make test kitchen show deprecation errors
also fix resource cloning error for Ubuntu 14.04 now that test kitchen is showing deprecation errors.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
