### PR TITLE
Fix an ignoring of 'cookbook' attribute by 'mysql_config' resource

### DIFF
--- a/libraries/mysql_config.rb
+++ b/libraries/mysql_config.rb
@@ -42,7 +42,7 @@ module MysqlCookbook
         mode '0640'
         variables(new_resource.variables)
         source new_resource.source
-        cookbook cookbook
+        cookbook new_resource.cookbook
         action :create
       end
     end


### PR DESCRIPTION
### Description

Fix an ignoring of 'cookbook' attribute by 'mysql_config' resource

### Issues Resolved

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>