### PR TITLE
Fix namespace collision deprecation warnings

### DIFF
--- a/libraries/mysql_client_installation_package.rb
+++ b/libraries/mysql_client_installation_package.rb
@@ -15,15 +15,15 @@ module MysqlCookbook
 
     # Actions
     action :create do
-      package package_name do
-        version package_version if package_version
-        options package_options if package_options
+      package new_resource.package_name do
+        version new_resource.package_version if new_resource.package_version
+        options new_resource.package_options if new_resource.package_options
         action :install
       end
     end
 
     action :delete do
-      package package_name do
+      package new_resource.package_name do
         action :remove
       end
     end

--- a/libraries/mysql_config.rb
+++ b/libraries/mysql_config.rb
@@ -19,16 +19,16 @@ module MysqlCookbook
     action :create do
       # hax because group property
       g = Chef::Resource::Group.new(new_resource.group, run_context)
-      g.system true if name == 'mysql'
+      g.system true if new_resource.name == 'mysql'
       resource_collection.insert g
 
-      user owner do
-        gid owner
-        system true if name == 'mysql'
+      user new_resource.owner do
+        gid new_resource.owner
+        system true if new_resource.name == 'mysql'
         action :create
       end
 
-      directory include_dir do
+      directory new_resource.include_dir do
         owner new_resource.owner
         group new_resource.group
         mode '0750'
@@ -36,7 +36,7 @@ module MysqlCookbook
         action :create
       end
 
-      template "#{include_dir}/#{config_name}.cnf" do
+      template "#{new_resource.include_dir}/#{new_resource.config_name}.cnf" do
         owner new_resource.owner
         group new_resource.group
         mode '0640'
@@ -48,7 +48,7 @@ module MysqlCookbook
     end
 
     action :delete do
-      file "#{include_dir}/#{config_name}.cnf" do
+      file "#{new_resource.include_dir}/#{new_resource.config_name}.cnf" do
         action :delete
       end
     end

--- a/libraries/mysql_server_installation_package.rb
+++ b/libraries/mysql_server_installation_package.rb
@@ -14,9 +14,9 @@ module MysqlCookbook
 
     # Actions
     action :install do
-      package package_name do
-        version package_version if package_version
-        options package_options if package_options
+      package new_resource.package_name do
+        version new_resource.package_version if new_resource.package_version
+        options new_resource.package_options if new_resource.package_options
         notifies :install, 'package[perl-Sys-Hostname-Long]', :immediately if platform_family?('suse')
         notifies :run, 'execute[Initial DB setup script]', :immediately if platform_family?('suse')
         action :install

--- a/libraries/mysql_service.rb
+++ b/libraries/mysql_service.rb
@@ -31,11 +31,11 @@ module MysqlCookbook
 
     action_class.class_eval do
       def installation(&block)
-        case install_method
+        case new_resource.install_method
         when 'auto'
-          install = mysql_server_installation(name, &block)
+          install = mysql_server_installation(new_resource.name, &block)
         when 'package'
-          install = mysql_server_installation_package(name, &block)
+          install = mysql_server_installation_package(new_resource.name, &block)
         when 'none'
           Chef::Log.info('Skipping MySQL installation. Assuming it was handled previously.')
           return
@@ -45,15 +45,15 @@ module MysqlCookbook
       end
 
       def svc_manager(&block)
-        case service_manager
+        case new_resource.service_manager
         when 'auto'
-          svc = mysql_service_manager(name, &block)
+          svc = mysql_service_manager(new_resource.name, &block)
         when 'sysvinit'
-          svc = mysql_service_manager_sysvinit(name, &block)
+          svc = mysql_service_manager_sysvinit(new_resource.name, &block)
         when 'upstart'
-          svc = mysql_service_manager_upstart(name, &block)
+          svc = mysql_service_manager_upstart(new_resource.name, &block)
         when 'systemd'
-          svc = mysql_service_manager_systemd(name, &block)
+          svc = mysql_service_manager_systemd(new_resource.name, &block)
         end
         copy_properties_to(svc)
         svc

--- a/libraries/mysql_service_base.rb
+++ b/libraries/mysql_service_base.rb
@@ -56,40 +56,40 @@ module MysqlCookbook
 
         # Support directories
         directory etc_dir do
-          owner run_user
-          group run_group
+          owner new_resource.run_user
+          group new_resource.run_group
           mode '0750'
           recursive true
           action :create
         end
 
-        directory include_dir do
-          owner run_user
-          group run_group
+        directory new_resource.include_dir do
+          owner new_resource.run_user
+          group new_resource.run_group
           mode '0750'
           recursive true
           action :create
         end
 
         directory run_dir do
-          owner run_user
-          group run_group
+          owner new_resource.run_user
+          group new_resource.run_group
           mode '0755'
           recursive true
           action :create
         end
 
         directory log_dir do
-          owner run_user
-          group run_group
+          owner new_resource.run_user
+          group new_resource.run_group
           mode '0750'
           recursive true
           action :create
         end
 
-        directory data_dir do
-          owner run_user
-          group run_group
+        directory new_resource.data_dir do
+          owner new_resource.run_user
+          group new_resource.run_group
           mode '0750'
           recursive true
           action :create
@@ -99,8 +99,8 @@ module MysqlCookbook
         template "#{etc_dir}/my.cnf" do
           source 'my.cnf.erb'
           cookbook 'mysql'
-          owner run_user
-          group run_group
+          owner new_resource.run_user
+          group new_resource.run_group
           mode '0600'
           variables(config: new_resource)
           action :create
@@ -109,11 +109,11 @@ module MysqlCookbook
 
       def initialize_database
         # initialize database and create initial records
-        bash "#{name} initial records" do
+        bash "#{new_resource.name} initial records" do
           code init_records_script
           umask '022'
           returns [0, 1, 2] # facepalm
-          not_if "/usr/bin/test -f #{data_dir}/mysql/user.frm"
+          not_if "/usr/bin/test -f #{new_resource.data_dir}/mysql/user.frm"
           action :run
         end
       end
@@ -166,7 +166,7 @@ module MysqlCookbook
           group 'root'
           mode '0644'
           action :create
-          notifies :restart, "service[#{instance} apparmor]", :immediately
+          notifies :restart, "service[#{new_resource.instance} apparmor]", :immediately
         end
 
         template '/etc/apparmor.d/usr.sbin.mysqld' do
@@ -176,10 +176,10 @@ module MysqlCookbook
           group 'root'
           mode '0644'
           action :create
-          notifies :restart, "service[#{instance} apparmor]", :immediately
+          notifies :restart, "service[#{new_resource.instance} apparmor]", :immediately
         end
 
-        template "/etc/apparmor.d/local/mysql/#{instance}" do
+        template "/etc/apparmor.d/local/mysql/#{new_resource.instance}" do
           cookbook 'mysql'
           source 'apparmor/usr.sbin.mysqld-instance.erb'
           owner 'root'
@@ -190,10 +190,10 @@ module MysqlCookbook
             mysql_name: mysql_name
           )
           action :create
-          notifies :restart, "service[#{instance} apparmor]", :immediately
+          notifies :restart, "service[#{new_resource.instance} apparmor]", :immediately
         end
 
-        service "#{instance} apparmor" do
+        service "#{new_resource.instance} apparmor" do
           service_name 'apparmor'
           action :nothing
         end

--- a/libraries/mysql_service_manager_systemd.rb
+++ b/libraries/mysql_service_manager_systemd.rb
@@ -51,12 +51,12 @@ module MysqlCookbook
           mysqld_bin: mysqld_bin
         )
         cookbook 'mysql'
-        notifies :run, "execute[#{instance} systemctl daemon-reload]", :immediately
+        notifies :run, "execute[#{new_resource.instance} systemctl daemon-reload]", :immediately
         action :create
       end
 
       # avoid 'Unit file changed on disk' warning
-      execute "#{instance} systemctl daemon-reload" do
+      execute "#{new_resource.instance} systemctl daemon-reload" do
         command '/bin/systemctl daemon-reload'
         action :nothing
       end
@@ -70,8 +70,8 @@ module MysqlCookbook
         mode '0644'
         variables(
           run_dir: run_dir,
-          run_user: run_user,
-          run_group: run_group
+          run_user: new_resource.run_user,
+          run_group: new_resource.run_group
         )
         cookbook 'mysql'
         action :create

--- a/libraries/mysql_service_manager_sysvinit.rb
+++ b/libraries/mysql_service_manager_sysvinit.rb
@@ -22,11 +22,11 @@ module MysqlCookbook
         variables(
           config: new_resource,
           defaults_file: defaults_file,
-          error_log: error_log,
+          error_log: new_resource.error_log,
           mysql_name: mysql_name,
           mysqladmin_bin: mysqladmin_bin,
           mysqld_safe_bin: mysqld_safe_bin,
-          pid_file: pid_file,
+          pid_file: new_resource.pid_file,
           scl_name: scl_name
         )
         cookbook 'mysql'

--- a/libraries/mysql_service_manager_upstart.rb
+++ b/libraries/mysql_service_manager_upstart.rb
@@ -37,9 +37,9 @@ module MysqlCookbook
         variables(
           defaults_file: defaults_file,
           mysql_name: mysql_name,
-          run_group: run_group,
-          run_user: run_user,
-          socket_dir: socket_dir
+          run_group: new_resource.run_group,
+          run_user: new_resource.run_user,
+          socket_dir: new_resource.socket_dir
         )
         cookbook 'mysql'
         action :create


### PR DESCRIPTION
Fixes the namespace collision deprecation warnings in recent Chef versions.

### Description
Using the short form of `property_name` inside resources is [deprecated and will be removed](https://docs.chef.io/deprecations_namespace_collisions.html) in favour of `new_resource.property_name` to avoid collisions between properties in different scopes.

This fixes a large list of deprecation warnings produced by the current version.

### Issues Resolved

#400 may be relevant although that actually appears to be referring to other properties that have already been removed.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] **(NA)** New functionality includes testing.
- [x] **(NA)** New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
