### PR TITLE
Update apparmor file

### DIFF
--- a/templates/default/apparmor/usr.sbin.mysqld.erb
+++ b/templates/default/apparmor/usr.sbin.mysqld.erb
@@ -1,5 +1,5 @@
 # vim:syntax=apparmor
-# Last Modified: Tue Jun 19 17:37:30 2007
+# Last Modified: Tue Feb 09 15:28:30 2016
 #include <tunables/global>
 
 /usr/sbin/mysqld {
@@ -9,38 +9,59 @@
   #include <abstractions/mysql>
   #include <abstractions/winbind>
 
-  capability dac_override,
+# Allow system resource access
+  /sys/devices/system/cpu/ r,
   capability sys_resource,
-  capability setgid,
+  capability dac_override,
   capability setuid,
+  capability setgid,
 
+# Allow network access
   network tcp,
 
   /etc/hosts.allow r,
   /etc/hosts.deny r,
 
-  /etc/mysql/*.pem r,
-  /etc/mysql/conf.d/ r,
-  /etc/mysql/conf.d/* r,
-  /etc/mysql/*.cnf r,
-  /usr/lib/mysql/plugin/ r,
-  /usr/lib/mysql/plugin/*.so* mr,
-  /usr/sbin/mysqld mr,
-  /usr/share/mysql/** r,
-  /var/log/mysql.log rw,
-  /var/log/mysql.err rw,
-  /var/lib/mysql/ r,
-  /var/lib/mysql/** rwk,
-  /var/log/mysql/ r,
-  /var/log/mysql/* rw,
+# Allow config access
+  /etc/mysql/** r,
+
+# Allow pid, socket, socket lock file access
   /var/run/mysqld/mysqld.pid rw,
-  /var/run/mysqld/mysqld.sock w,
+  /var/run/mysqld/mysqld.sock rw,
   /var/run/mysqld/mysqld.sock.lock rw,
   /run/mysqld/mysqld.pid rw,
-  /run/mysqld/mysqld.sock w,
+  /run/mysqld/mysqld.sock rw,
   /run/mysqld/mysqld.sock.lock rw,
 
-  /sys/devices/system/cpu/ r,
+# Allow execution of server binary
+  /usr/sbin/mysqld mr,
+  /usr/sbin/mysqld-debug mr,
+
+# Allow plugin access
+  /usr/lib/mysql/plugin/ r,
+  /usr/lib/mysql/plugin/*.so* mr,
+
+# Allow error msg and charset access
+  /usr/share/mysql/ r,
+  /usr/share/mysql/** r,
+
+# Allow data dir access
+  /var/lib/mysql/ r,
+  /var/lib/mysql/** rwk,
+
+# Allow data files dir access
+  /var/lib/mysql-files/ r,
+  /var/lib/mysql-files/** rwk,
+
+# Allow keyring dir access
+  /var/lib/mysql-keyring/ r,
+  /var/lib/mysql-keyring/** rwk,
+
+# Allow log file access
+  /var/log/mysql.err rw,
+  /var/log/mysql.log rw,
+  /var/log/mysql/ r,
+  /var/log/mysql/** rw,
 
   # Site-specific additions and overrides. See local/README for details.
   #include <local/usr.sbin.mysqld>


### PR DESCRIPTION
the old apparmor file was stopping apt-get-upgrade from working for me
on ubuntu 16.04

this new file was obtained by taking a clean ubuntu install, then
running
sudo apt-get install mysql-server

### Description

updates to current apparmor file



### Issues Resolved

previously, I could install mysql on ubuntu with this recipe - but after a month or two, there would be an update to mysql, and sudo apt-get update would fail with errors like the following

```
ERROR: Unable to start MySQL server:
mysqld: Can't read dir of '/etc/mysql/mysql.conf.d/' (Errcode: 13 - Permission denied)
mysqld: [ERROR] Fatal error in defaults handling. Program aborted!
Please take a look at https://wiki.debian.org/Teams/MySQL/FAQ for tips on fixing common upgrade issues.
Once the problem is resolved, run apt-get --fix-broken install to retry.
dpkg: error processing package mysql-server-5.7 (--configure):
 subprocess installed post-installation script returned error exit status 1
```

digging into logs shows apparmor errors like the following
```

Feb  7 19:13:05 recruit-beta-2 kernel: [349642.873317] audit: type=1400 audit(1518030785.238:25): apparmor="STATUS" operation="profile_replace" profile="unconfined" name="/usr/sbin/mysqld" pid=26661 comm="apparmor_parser"

Feb  7 19:13:05 recruit-beta-2 kernel: [349642.937481] audit: type=1400 audit(1518030785.302:26): apparmor="DENIED" operation="open" profile="/usr/sbin/mysqld" name="/proc/26679/status" pid=26679 comm="mysqld" requested_mask="r" denied_mask="r" fsuid=0 ouid=0

Feb  7 19:13:05 recruit-beta-2 kernel: [349642.937687] audit: type=1400 audit(1518030785.302:27): apparmor="DENIED" operation="open" profile="/usr/sbin/mysqld" name="/sys/devices/system/node/" pid=26679 comm="mysqld" requested_mask="r" denied_mask="r" fsuid=0 ouid=0

Feb  7 19:13:05 recruit-beta-2 kernel: [349642.937819] audit: type=1400 audit(1518030785.302:28): apparmor="DENIED" operation="open" profile="/usr/sbin/mysqld" name="/proc/26679/status" pid=26679 comm="mysqld" requested_mask="r" denied_mask="r" fsuid=0 ouid=0

Feb  7 19:13:05 recruit-beta-2 kernel: [349642.952771] audit: type=1400 audit(1518030785.318:29): apparmor="DENIED" operation="open" profile="/usr/sbin/mysqld" name="/etc/mysql/mysql.conf.d/" pid=26679 comm="mysqld" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
```

### Check List

this is beyond my expertise I'm afraid.

- [ no] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ n/a] New functionality includes testing.
- [ n/a] New functionality has been documented in the README if applicable
- [ no] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
