### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
     sources:
       - chef-current-trusty
     packages:
-      - chefdk
+      - chefdk=2.5.8-1
 
 # Don't `bundle install` which takes about 1.5 mins
 install: echo "skip bundle install"


### PR DESCRIPTION
### Description

With chefdk 3.0 the command`chef shell-init bash` fails causing the build to fail.
Pinning the version to 2.5.8 fixes the build.

An issue has been created for chef-dk:
https://github.com/chef/chef-dk/issues/1579

### Issues Resolved

All builds are failing

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
